### PR TITLE
feat: 실시간 대기열 지도 sse 추가

### DIFF
--- a/src/main/java/com/goorm/ticker/common/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/ticker/common/exception/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode {
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST,"중복된 유저이름입니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND,"존재하지 않는 유저입니다."),
     LOGIN_FAIL(HttpStatus.UNAUTHORIZED,"비밀번호가 일치하지 않습니다."),
-    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED,"세션이 만료되었습니다.");
+    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED,"세션이 만료되었습니다."),
+
+    // Restaurant
+    NOT_FOUND_RESTAURANT(HttpStatus.NOT_FOUND,"존재하지 않는 식당입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/goorm/ticker/map/controller/MapController.java
+++ b/src/main/java/com/goorm/ticker/map/controller/MapController.java
@@ -1,0 +1,35 @@
+package com.goorm.ticker.map.controller;
+
+import com.goorm.ticker.map.service.MapService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+@Tag(name="Maps", description = "지도 SSE 연결")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/maps")
+public class MapController {
+    private final MapService mapService;
+
+    @Operation(summary = "지도 SSE 연결", description = "url 파라미터에 유저의 id, 실시간으로 조회하고 싶은 음식점의 정보들을 쿼리 파라미터에 넣어 (음식점의 아이디들,x 좌표들, y좌표들, 이름들)리스트 형식으로 보내주세요. ex)restaurantId=1,2,3,4 & x=1,2,3,4 & y=1,2,3,4 & name = 음식점1,음식점2,음식점3,음식점4")
+    @GetMapping(value = "/{userId}",produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter sub(@PathVariable Long userId, @RequestParam List<Long> restaurantId, @RequestParam List<String> x, @RequestParam List<String> y, @RequestParam List<String> name){
+        return mapService.addEmitter(userId,x,y,restaurantId,name);
+    }
+
+    //대기열 변화 테스트용 api입니다
+    /*@GetMapping(value = "/test/{restaurantId}")
+    public Long test(@RequestParam Long restaurantId, @RequestParam int waiting){
+        mapService.updateMap(restaurantId,waiting);
+        return restaurantId;
+    }*/
+
+
+}

--- a/src/main/java/com/goorm/ticker/map/controller/MapController.java
+++ b/src/main/java/com/goorm/ticker/map/controller/MapController.java
@@ -3,7 +3,6 @@ package com.goorm.ticker.map.controller;
 import com.goorm.ticker.map.service.MapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -23,13 +22,5 @@ public class MapController {
     public SseEmitter sub(@PathVariable Long userId, @RequestParam List<Long> restaurantId, @RequestParam List<String> x, @RequestParam List<String> y, @RequestParam List<String> name){
         return mapService.addEmitter(userId,x,y,restaurantId,name);
     }
-
-    //대기열 변화 테스트용 api입니다
-    /*@GetMapping(value = "/test/{restaurantId}")
-    public Long test(@RequestParam Long restaurantId, @RequestParam int waiting){
-        mapService.updateMap(restaurantId,waiting);
-        return restaurantId;
-    }*/
-
 
 }

--- a/src/main/java/com/goorm/ticker/map/dto/MapUpdateDto.java
+++ b/src/main/java/com/goorm/ticker/map/dto/MapUpdateDto.java
@@ -7,13 +7,20 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class MapUpdateDto {
     private Long restaurantId;
-    private String name;
+    private String restaurantName;
     private String x;
     private String y;
-    private int waiting;
+    private Long waiting;
+
+    public MapUpdateDto(Long restaurantId, String restaurantName, String x, String y, Long waiting) {
+        this.restaurantId = restaurantId;
+        this.restaurantName = restaurantName;
+        this.x = x;
+        this.y = y;
+        this.waiting = waiting;
+    }
 
 }

--- a/src/main/java/com/goorm/ticker/map/dto/MapUpdateDto.java
+++ b/src/main/java/com/goorm/ticker/map/dto/MapUpdateDto.java
@@ -1,0 +1,19 @@
+package com.goorm.ticker.map.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MapUpdateDto {
+    private Long restaurantId;
+    private String name;
+    private String x;
+    private String y;
+    private int waiting;
+
+}

--- a/src/main/java/com/goorm/ticker/map/service/MapService.java
+++ b/src/main/java/com/goorm/ticker/map/service/MapService.java
@@ -7,6 +7,8 @@ import com.goorm.ticker.map.dto.MapUpdateDto;
 import com.goorm.ticker.map.util.RestaurantEmitter;
 import com.goorm.ticker.restaurant.entity.Restaurant;
 import com.goorm.ticker.restaurant.repository.RestaurantRepository;
+import com.goorm.ticker.waitlist.repository.WaitListRepository;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
@@ -23,11 +26,11 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 public class MapService {
     private final RestaurantRepository restaurantRepository;
-
     private final Map<Long, RestaurantEmitter> emitters = new ConcurrentHashMap<>();
-    private final Map<Long, List<Long>> viewer = new ConcurrentHashMap<>();
+    private final Map<Long, Set<Long>> viewer = new ConcurrentHashMap<>();
     private final long timeout = 60 * 60 * 1000L;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WaitListRepository waitListRepository;
 
 
     /*
@@ -36,27 +39,14 @@ public class MapService {
     @Transactional
     public SseEmitter addEmitter(Long userId, List<String> x, List<String> y, List<Long> restaurantId, List<String> name){
         SseEmitter emitter = new SseEmitter(timeout);
-        List<MapUpdateDto> dto = new ArrayList<>();
-        List<Restaurant> restaurants = new ArrayList<>();
-        List<Long> ids = restaurantRepository.findExistingIds(restaurantId);
         /*
         각 식당이 db에 존재하는지 확인, 없다면 식당을 db에 추가
          */
-        for(int i = 0 ; i < restaurantId.size();i++){
-            if(!ids.contains(restaurantId.get(i))){
-                restaurants.add(Restaurant.builder().restaurantId(restaurantId.get(i)).x(x.get(i)).y(y.get(i)).restaurantName(name.get(i)).maxWaiting(Integer.MAX_VALUE).build());
-            }
-            /*
-            해당 식당의 대기열 수를 조회
-            */
-            MapUpdateDto mapUpdateDto = MapUpdateDto.builder().restaurantId(restaurantId.get(i)).x(x.get(i)).y(y.get(i)).name(name.get(i)).waiting(0/*조회된 대기열*/).build();
-            dto.add(mapUpdateDto);
+        saveRestaurants( x, y, restaurantId, name);
+        List<MapUpdateDto> dto = waitListRepository.findRestaurantsWithWaiting(restaurantId);
+        for(Long rest : restaurantId){
+            viewer.computeIfAbsent(rest, k -> ConcurrentHashMap.newKeySet()).add(userId);
         }
-        restaurantRepository.saveAll(restaurants);
-         // 2번 케이스에 대한 방법입니다.
-        /*for(Long rest : restaurantId){
-            viewer.computeIfAbsent(rest, k -> new CopyOnWriteArrayList<>()).add(userId);
-        }*/
 
         /*
         현재 접속한 사용자와 사용자가 실시간 대기열 조회를 하는 음식점을 저장
@@ -72,44 +62,49 @@ public class MapService {
         catch (Exception e){
             log.info(e.getMessage());
         }
-        emitter.onCompletion(() -> emitters.remove(userId));
-        emitter.onTimeout(() -> emitters.remove(userId));
+
+        emitter.onCompletion(() -> {
+            emitters.remove(userId);
+            remove(userId);
+        });
+        emitter.onTimeout(() -> {
+            emitters.remove(userId);
+            remove(userId);
+        });
         return  emitter;
+
     }
 
+    @Transactional
+    public void saveRestaurants(List<String> x, List<String> y, List<Long> restaurantId, List<String> name){
+        List<Long> ids = restaurantRepository.findExistingIds(restaurantId);
+        List<Restaurant> restaurants = new ArrayList<>();
+        for(int i = 0 ; i < restaurantId.size();i++){
+            if(!ids.contains(restaurantId.get(i))){
+                restaurants.add(Restaurant.builder().restaurantId(restaurantId.get(i)).x(x.get(i)).y(y.get(i)).restaurantName(name.get(i)).maxWaiting(Integer.MAX_VALUE).build());
+            }
+        }
+        restaurantRepository.saveAll(restaurants);
+    }
 
-    //2번 케이스의 삭제 로직
-    /*public void remove(Long userId){
+    public void remove(Long userId){
         viewer.forEach((rest, viewers)->{
             viewers.remove(userId);
         });
         emitters.remove(userId);
-    }*/
-    /*
-        식당의 대기열에 변화가 생기면 해당 식당의 id와 변경된 대기열을 현재 그 식당을 조회하고 있는 회원들에게 변동된 대기열에 대해 알림을 보냅니다.
-        개선 방향
-        1. 현재 방식 유지 (현재 조회 중인 모든 사람들의 음식점을 풀스캔) - 느림
-        2. 식당 관련 맵을 하나 더 만들어서 관리 ( 맵 규모 2배로 커짐 ) - 매우 빠름
-    */
-    public void updateMap(Long restaurantId, int waiting){
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(()->new CustomException(ErrorCode.RESTAURANT_NOT_FOUND));
-        MapUpdateDto mapUpdateDto = MapUpdateDto.builder().restaurantId(restaurantId).x(restaurant.getX()).y(restaurant.getY()).name(restaurant.getRestaurantName()).waiting(waiting).build();
-        /*
-        갱신된 대기열에 대한 정보를 해당 음식점을 조회 중인 사용자를 전부 찾아 전달
-         */
-        emitters.forEach((userId,restaurantEmitter)->{
-            if(restaurantEmitter.getRestaurantId().contains(restaurantId)){
-                try {
-                    restaurantEmitter.getEmitter().send(SseEmitter.event().name("update").id(userId.toString()).data(objectMapper.writeValueAsString(mapUpdateDto)));
-                }
-                catch (Exception e){
-                    log.info(e.getMessage());
-                }
-            }
-        });
+    }
 
-        /*
-            2번 케이스에 대한 방법입니다.
+    //대기열 업데이트를 트리거로 해당 식당을 조회 중인 사용자에게 전달
+    public void updateMap(Long restaurantId){
+        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(()->new CustomException(ErrorCode.RESTAURANT_NOT_FOUND));
+        long waiting = waitListRepository.countTotalWaitingByRestaurantId(restaurantId);
+        MapUpdateDto mapUpdateDto = MapUpdateDto.builder()
+                .restaurantId(restaurantId)
+                .restaurantName(restaurant.getRestaurantName())
+                .x(restaurant.getX())
+                .y(restaurant.getY())
+                .waiting(waiting)
+                .build();
         for(Long user : viewer.get(restaurantId)){
             try {
                 emitters.get(user).getEmitter().send(SseEmitter.event().name("update").id(user.toString()).data(objectMapper.writeValueAsString(mapUpdateDto)));
@@ -119,6 +114,5 @@ public class MapService {
             }
         }
 
-         */
     }
 }

--- a/src/main/java/com/goorm/ticker/map/service/MapService.java
+++ b/src/main/java/com/goorm/ticker/map/service/MapService.java
@@ -1,0 +1,124 @@
+package com.goorm.ticker.map.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.ticker.common.exception.CustomException;
+import com.goorm.ticker.common.exception.ErrorCode;
+import com.goorm.ticker.map.dto.MapUpdateDto;
+import com.goorm.ticker.map.util.RestaurantEmitter;
+import com.goorm.ticker.restaurant.entity.Restaurant;
+import com.goorm.ticker.restaurant.repository.RestaurantRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MapService {
+    private final RestaurantRepository restaurantRepository;
+
+    private final Map<Long, RestaurantEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<Long, List<Long>> viewer = new ConcurrentHashMap<>();
+    private final long timeout = 60 * 60 * 1000L;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+
+    /*
+    SSE에 연결하는 메소드로 해당 식당의 정보와 접속 중인 유저의 id를 받아 유저의 id를 키로, 현재 조회 중인 식당의 정보를 저장하고 연결합니다.
+     */
+    @Transactional
+    public SseEmitter addEmitter(Long userId, List<String> x, List<String> y, List<Long> restaurantId, List<String> name){
+        SseEmitter emitter = new SseEmitter(timeout);
+        List<MapUpdateDto> dto = new ArrayList<>();
+        List<Restaurant> restaurants = new ArrayList<>();
+        List<Long> ids = restaurantRepository.findExistingIds(restaurantId);
+        /*
+        각 식당이 db에 존재하는지 확인, 없다면 식당을 db에 추가
+         */
+        for(int i = 0 ; i < restaurantId.size();i++){
+            if(!ids.contains(restaurantId.get(i))){
+                restaurants.add(Restaurant.builder().restaurantId(restaurantId.get(i)).x(x.get(i)).y(y.get(i)).restaurantName(name.get(i)).maxWaiting(Integer.MAX_VALUE).build());
+            }
+            /*
+            해당 식당의 대기열 수를 조회
+            */
+            MapUpdateDto mapUpdateDto = MapUpdateDto.builder().restaurantId(restaurantId.get(i)).x(x.get(i)).y(y.get(i)).name(name.get(i)).waiting(0/*조회된 대기열*/).build();
+            dto.add(mapUpdateDto);
+        }
+        restaurantRepository.saveAll(restaurants);
+         // 2번 케이스에 대한 방법입니다.
+        /*for(Long rest : restaurantId){
+            viewer.computeIfAbsent(rest, k -> new CopyOnWriteArrayList<>()).add(userId);
+        }*/
+
+        /*
+        현재 접속한 사용자와 사용자가 실시간 대기열 조회를 하는 음식점을 저장
+         */
+        RestaurantEmitter restaurantEmitter = RestaurantEmitter.builder().emitter(emitter).restaurantId(restaurantId).build();
+        emitters.put(userId,restaurantEmitter);
+        /*
+        현재 조회 중인 음식점들의 대기열을 제공
+         */
+        try {
+            emitter.send(SseEmitter.event().name("connect").id(userId.toString()).data(objectMapper.writeValueAsString(dto)));
+        }
+        catch (Exception e){
+            log.info(e.getMessage());
+        }
+        emitter.onCompletion(() -> emitters.remove(userId));
+        emitter.onTimeout(() -> emitters.remove(userId));
+        return  emitter;
+    }
+
+
+    //2번 케이스의 삭제 로직
+    /*public void remove(Long userId){
+        viewer.forEach((rest, viewers)->{
+            viewers.remove(userId);
+        });
+        emitters.remove(userId);
+    }*/
+    /*
+        식당의 대기열에 변화가 생기면 해당 식당의 id와 변경된 대기열을 현재 그 식당을 조회하고 있는 회원들에게 변동된 대기열에 대해 알림을 보냅니다.
+        개선 방향
+        1. 현재 방식 유지 (현재 조회 중인 모든 사람들의 음식점을 풀스캔) - 느림
+        2. 식당 관련 맵을 하나 더 만들어서 관리 ( 맵 규모 2배로 커짐 ) - 매우 빠름
+    */
+    public void updateMap(Long restaurantId, int waiting){
+        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(()->new CustomException(ErrorCode.NOT_FOUND_RESTAURANT));
+        MapUpdateDto mapUpdateDto = MapUpdateDto.builder().restaurantId(restaurantId).x(restaurant.getX()).y(restaurant.getY()).name(restaurant.getRestaurantName()).waiting(waiting).build();
+        /*
+        갱신된 대기열에 대한 정보를 해당 음식점을 조회 중인 사용자를 전부 찾아 전달
+         */
+        emitters.forEach((userId,restaurantEmitter)->{
+            if(restaurantEmitter.getRestaurantId().contains(restaurantId)){
+                try {
+                    restaurantEmitter.getEmitter().send(SseEmitter.event().name("update").id(userId.toString()).data(objectMapper.writeValueAsString(mapUpdateDto)));
+                }
+                catch (Exception e){
+                    log.info(e.getMessage());
+                }
+            }
+        });
+
+        /*
+            2번 케이스에 대한 방법입니다.
+        for(Long user : viewer.get(restaurantId)){
+            try {
+                emitters.get(user).getEmitter().send(SseEmitter.event().name("update").id(user.toString()).data(objectMapper.writeValueAsString(mapUpdateDto)));
+            }
+            catch (Exception e){
+                log.info(e.getMessage());
+            }
+        }
+
+         */
+    }
+}

--- a/src/main/java/com/goorm/ticker/map/service/MapService.java
+++ b/src/main/java/com/goorm/ticker/map/service/MapService.java
@@ -92,7 +92,7 @@ public class MapService {
         2. 식당 관련 맵을 하나 더 만들어서 관리 ( 맵 규모 2배로 커짐 ) - 매우 빠름
     */
     public void updateMap(Long restaurantId, int waiting){
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(()->new CustomException(ErrorCode.NOT_FOUND_RESTAURANT));
+        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(()->new CustomException(ErrorCode.RESTAURANT_NOT_FOUND));
         MapUpdateDto mapUpdateDto = MapUpdateDto.builder().restaurantId(restaurantId).x(restaurant.getX()).y(restaurant.getY()).name(restaurant.getRestaurantName()).waiting(waiting).build();
         /*
         갱신된 대기열에 대한 정보를 해당 음식점을 조회 중인 사용자를 전부 찾아 전달

--- a/src/main/java/com/goorm/ticker/map/util/RestaurantEmitter.java
+++ b/src/main/java/com/goorm/ticker/map/util/RestaurantEmitter.java
@@ -1,0 +1,18 @@
+package com.goorm.ticker.map.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class RestaurantEmitter {
+    private SseEmitter emitter;
+    private List<Long> restaurantId;
+}

--- a/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
@@ -6,21 +6,17 @@ import java.util.List;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "restaurants")
 public class Restaurant {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "restaurant_id")
 	private Long restaurantId;
 
@@ -38,5 +34,16 @@ public class Restaurant {
 
 	@OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ReservationSlot> reservationSlots = new ArrayList<>();
+
+	@Builder
+	public Restaurant(Long restaurantId, String restaurantName, String x, String y, Integer maxWaiting){
+		this.restaurantId = restaurantId;
+		this.restaurantName  = restaurantName;
+		this.x = x;
+		this.y = y;
+		this.maxWaiting = maxWaiting;
+	}
+
+
 
 }

--- a/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "restaurants")
 public class Restaurant {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "restaurant_id")
 	private Long restaurantId;
 
@@ -36,12 +35,14 @@ public class Restaurant {
 	@Column(name = "max_waiting", nullable = false)
 	private Integer maxWaiting;
 
-	public static Restaurant of(String restaurantName, String x, String y, Integer maxWaiting) {
+
+	public static Restaurant of(Long restaurantId,String restaurantName, String x, String y, Integer maxWaiting) {
 		return Restaurant.builder()
-			.restaurantName(restaurantName)
-			.x(x)
-			.y(y)
-			.maxWaiting(maxWaiting)
-			.build();
+				.restaurantId(restaurantId)
+				.restaurantName(restaurantName)
+				.x(x)
+				.y(y)
+				.maxWaiting(maxWaiting)
+				.build();
 	}
 }

--- a/src/main/java/com/goorm/ticker/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/goorm/ticker/restaurant/repository/RestaurantRepository.java
@@ -3,6 +3,12 @@ package com.goorm.ticker.restaurant.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goorm.ticker.restaurant.entity.Restaurant;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+    @Query("SELECT r.restaurantId FROM Restaurant r WHERE r.restaurantId IN :ids")
+    List<Long> findExistingIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/goorm/ticker/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/goorm/ticker/restaurant/repository/RestaurantRepository.java
@@ -1,0 +1,13 @@
+package com.goorm.ticker.restaurant.repository;
+
+import com.goorm.ticker.restaurant.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+    @Query("SELECT r.restaurantId FROM Restaurant r WHERE r.restaurantId IN :ids")
+    List<Long> findExistingIds(@Param("ids") List<Long> ids);
+}

--- a/src/main/java/com/goorm/ticker/waitlist/repository/WaitListRepository.java
+++ b/src/main/java/com/goorm/ticker/waitlist/repository/WaitListRepository.java
@@ -1,11 +1,13 @@
 package com.goorm.ticker.waitlist.repository;
 
+import com.goorm.ticker.map.dto.MapUpdateDto;
 import com.goorm.ticker.waitlist.entity.Status;
 import com.goorm.ticker.waitlist.entity.WaitList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WaitListRepository extends JpaRepository<WaitList, Long> {
@@ -24,4 +26,22 @@ public interface WaitListRepository extends JpaRepository<WaitList, Long> {
     List<WaitList> findByRestaurant_RestaurantIdAndWaitingNumberGreaterThan(Long restaurantId, int waitingNumber);
     List<WaitList> findByRestaurant_RestaurantIdAndStatusOrderByWaitingNumberAsc(Long restaurantId, Status status);
     */
+
+
+    @Query("""
+    SELECT new com.goorm.ticker.map.dto.MapUpdateDto(
+        r.restaurantId,
+        r.restaurantName,
+        r.x,
+        r.y,
+        COUNT(w)
+    )
+    FROM Restaurant r 
+    LEFT JOIN WaitList w ON r = w.restaurant AND w.status = 'WAITING' 
+    WHERE r.restaurantId IN :restaurantIds 
+    GROUP BY r
+""")
+    List<MapUpdateDto> findRestaurantsWithWaiting(@Param("restaurantIds") List<Long> restaurantIds);
+
+
 }

--- a/src/main/java/com/goorm/ticker/waitlist/service/CancelWaitingService.java
+++ b/src/main/java/com/goorm/ticker/waitlist/service/CancelWaitingService.java
@@ -2,6 +2,7 @@ package com.goorm.ticker.waitlist.service;
 
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.common.exception.ErrorCode;
+import com.goorm.ticker.map.service.MapService;
 import com.goorm.ticker.waitlist.entity.Status;
 import com.goorm.ticker.waitlist.entity.WaitList;
 import com.goorm.ticker.waitlist.repository.WaitListRepository;
@@ -16,6 +17,7 @@ public class CancelWaitingService {
 
     private final WaitListRepository waitListRepository;
     private final HttpSession httpSession;
+    private final MapService mapService;
 
     @Transactional
     public void cancelWaiting() {
@@ -26,6 +28,9 @@ public class CancelWaitingService {
         WaitList waitList = findUserWaitingList(userId);
 
         waitList.updateStatus(Status.CANCELLED);
+
+        //지도 대기열 업데이트
+        mapService.updateMap(waitList.getRestaurant().getRestaurantId());
     }
 
     private Long getSessionUserId() {

--- a/src/main/java/com/goorm/ticker/waitlist/service/CompleteWaitingService.java
+++ b/src/main/java/com/goorm/ticker/waitlist/service/CompleteWaitingService.java
@@ -2,6 +2,7 @@ package com.goorm.ticker.waitlist.service;
 
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.common.exception.ErrorCode;
+import com.goorm.ticker.map.service.MapService;
 import com.goorm.ticker.waitlist.entity.Status;
 import com.goorm.ticker.waitlist.entity.WaitList;
 import com.goorm.ticker.waitlist.repository.WaitListRepository;
@@ -16,6 +17,7 @@ public class CompleteWaitingService {
 
     private final WaitListRepository waitListRepository;
     private final HttpSession httpSession;
+    private final MapService mapService;
 
     @Transactional
     public void completeWaiting() {
@@ -26,6 +28,9 @@ public class CompleteWaitingService {
         WaitList waitList = findUserWaitingList(userId);
 
         waitList.updateStatus(Status.ENTERED);
+
+        //지도 대기열 업데이트
+        mapService.updateMap(waitList.getRestaurant().getRestaurantId());
     }
 
     private Long getSessionUserId() {

--- a/src/main/java/com/goorm/ticker/waitlist/service/RegisterWaitingService.java
+++ b/src/main/java/com/goorm/ticker/waitlist/service/RegisterWaitingService.java
@@ -2,6 +2,7 @@ package com.goorm.ticker.waitlist.service;
 
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.common.exception.ErrorCode;
+import com.goorm.ticker.map.service.MapService;
 import com.goorm.ticker.restaurant.entity.Restaurant;
 import com.goorm.ticker.restaurant.repository.RestaurantRepository;
 import com.goorm.ticker.user.entity.User;
@@ -23,6 +24,7 @@ public class RegisterWaitingService {
     private final RestaurantRepository restaurantRepository;
     private final WaitListRepository waitListRepository;
     private final HttpSession httpSession;
+    private final MapService mapService;
 
     public WaitListResponseDto registerWaiting(WaitListRequestDto request) {
         // 세션에서 사용자 ID 가져오기
@@ -41,6 +43,9 @@ public class RegisterWaitingService {
         // 대기열 등록 및 저장
         WaitList waitList = WaitList.createWaitList(user, restaurant, newWaitingNumber);
         waitListRepository.save(waitList);
+
+        //지도에서 해당 식당 대기열 업데이트
+        mapService.updateMap(request.restaurantId());
 
         return new WaitListResponseDto(waitList);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,8 @@ server:
   servlet:
     session:
       timeout: 30m
+    encoding:
+      force: true
+      charset: UTF-8
+      enabled: true
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,11 +15,12 @@ spring:
         format_sql: true
     open-in-view: false
 
-  redis:
-    host: localhost
-    port: 6379
-
 server:
   servlet:
     session:
       timeout: 30m
+    encoding:
+      force: true
+      charset: UTF-8
+      enabled: true
+

--- a/src/test/java/com/goorm/ticker/fixture/RestaurantFixture.java
+++ b/src/test/java/com/goorm/ticker/fixture/RestaurantFixture.java
@@ -4,22 +4,26 @@ import com.goorm.ticker.restaurant.entity.Restaurant;
 
 public enum RestaurantFixture {
 	RESTAURANT_FIXTURE_1(
+			1L,
 		"Test Restaurant 1",
 		"37.5665",
 		"126.9780",
 		50),
 	RESTAURANT_FIXTURE_2(
+			2L,
 		"Test Restaurant 2",
 		"37.5675",
 		"126.9790",
 		30);
+	private final Long restaurantId;
 
 	private final String name;
 	private final String x;
 	private final String y;
 	private final Integer maxWaiting;
 
-	RestaurantFixture(String name, String x, String y, Integer maxWaiting) {
+	RestaurantFixture(Long restaurantId,String name, String x, String y, Integer maxWaiting) {
+		this.restaurantId = restaurantId;
 		this.name = name;
 		this.x = x;
 		this.y = y;
@@ -27,7 +31,7 @@ public enum RestaurantFixture {
 	}
 
 	public Restaurant createRestaurant() {
-		return Restaurant.of(name, x, y, maxWaiting);
+		return Restaurant.of(restaurantId,name, x, y, maxWaiting);
 	}
 
 }

--- a/src/test/java/com/goorm/ticker/waitlist/controller/WaitListControllerTest.java
+++ b/src/test/java/com/goorm/ticker/waitlist/controller/WaitListControllerTest.java
@@ -1,6 +1,7 @@
 package com.goorm.ticker.waitlist.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.ticker.map.service.MapService;
 import com.goorm.ticker.restaurant.entity.Restaurant;
 import com.goorm.ticker.restaurant.repository.RestaurantRepository;
 import com.goorm.ticker.user.entity.User;
@@ -18,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +44,8 @@ public class WaitListControllerTest {
 
     @Autowired
     private RestaurantRepository restaurantRepository;
+    @MockitoBean
+    private MapService mapService;
 
     private MockHttpSession session;
     private Long testRestaurantId;
@@ -57,6 +61,7 @@ public class WaitListControllerTest {
                 .build());
 
         Restaurant restaurant = restaurantRepository.save(Restaurant.builder()
+                        .restaurantId(1L)
                 .restaurantName("test")
                 .x("testX")
                 .y("testY")

--- a/src/test/java/com/goorm/ticker/waitlist/service/CancelWaitingServiceTest.java
+++ b/src/test/java/com/goorm/ticker/waitlist/service/CancelWaitingServiceTest.java
@@ -2,6 +2,8 @@ package com.goorm.ticker.waitlist.service;
 
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.common.exception.ErrorCode;
+import com.goorm.ticker.map.service.MapService;
+import com.goorm.ticker.restaurant.entity.Restaurant;
 import com.goorm.ticker.waitlist.entity.Status;
 import com.goorm.ticker.waitlist.entity.WaitList;
 import com.goorm.ticker.waitlist.repository.WaitListRepository;
@@ -17,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +30,8 @@ public class CancelWaitingServiceTest {
 
     @Mock
     private WaitListRepository waitListRepository;
+    @Mock
+    private MapService mapService;
 
     @Mock
     private HttpSession session;
@@ -34,6 +39,7 @@ public class CancelWaitingServiceTest {
     @BeforeEach
     void setUp() {
         when(session.getAttribute("user")).thenReturn(1L);
+
     }
 
     @Test
@@ -43,10 +49,12 @@ public class CancelWaitingServiceTest {
         WaitList waitList = WaitList.builder()
                 .waitingNumber(1)
                 .status(Status.WAITING)
+                .restaurant(Restaurant.builder().restaurantId(1L).build())
                 .build();
 
         when(waitListRepository.findByUser_IdAndStatus(1L, Status.WAITING))
                 .thenReturn(Optional.of(waitList));
+
 
         // when
         cancelWaitingService.cancelWaiting();

--- a/src/test/java/com/goorm/ticker/waitlist/service/CompleteWaitingServiceTest.java
+++ b/src/test/java/com/goorm/ticker/waitlist/service/CompleteWaitingServiceTest.java
@@ -2,6 +2,8 @@ package com.goorm.ticker.waitlist.service;
 
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.common.exception.ErrorCode;
+import com.goorm.ticker.map.service.MapService;
+import com.goorm.ticker.restaurant.entity.Restaurant;
 import com.goorm.ticker.waitlist.entity.Status;
 import com.goorm.ticker.waitlist.entity.WaitList;
 import com.goorm.ticker.waitlist.repository.WaitListRepository;
@@ -27,6 +29,8 @@ public class CompleteWaitingServiceTest {
 
     @Mock
     private WaitListRepository waitListRepository;
+    @Mock
+    private MapService mapService;
 
     @Mock
     private HttpSession session;
@@ -43,6 +47,7 @@ public class CompleteWaitingServiceTest {
         WaitList waitList = WaitList.builder()
                 .waitingNumber(1)
                 .status(Status.WAITING)
+                .restaurant(Restaurant.builder().restaurantId(1L).build())
                 .build();
 
         when(waitListRepository.findByUser_IdAndStatus(1L, Status.WAITING))

--- a/src/test/java/com/goorm/ticker/waitlist/service/RegisterWaitingServiceTest.java
+++ b/src/test/java/com/goorm/ticker/waitlist/service/RegisterWaitingServiceTest.java
@@ -2,6 +2,7 @@ package com.goorm.ticker.waitlist.service;
 
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.common.exception.ErrorCode;
+import com.goorm.ticker.map.service.MapService;
 import com.goorm.ticker.restaurant.entity.Restaurant;
 import com.goorm.ticker.restaurant.repository.RestaurantRepository;
 import com.goorm.ticker.user.entity.User;
@@ -44,6 +45,8 @@ class RegisterWaitingServiceTest {
 
     @Mock
     private HttpSession session;
+    @Mock
+    private MapService mapService;
 
     private User testUser;
     private Restaurant testRestaurant;


### PR DESCRIPTION
## **PR 타입 (하나 이상의 PR 타입을 선택해주세요)**

- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## **반영 브랜치**
feature/#5 -> dev


## **이슈**
- close #{5}


## **작업 사항**
- 지도에 검색된 음식점의 정보에 대한 실시간 대기열 제공
- 대기열이 바뀔 때 마다 알림


## **리뷰어에게 전달 사항 (없으면 삭제)**
- 현재 대기열을 조회하는 로직 부분 없이 구현했습니다. 추후에 기능 올라오면 추가하겠습니다.
- 사용자 관리에 속도 효율과 메모리 효율에 대한 2가지 방식이 있습니다. 추후에 부하테스트 진행하겠습니다.
