### PR TITLE
Feature/#3 예약 정책 추가 및 락 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goorm/ticker/reservation/Entity/Reservation.java
+++ b/src/main/java/com/goorm/ticker/reservation/Entity/Reservation.java
@@ -69,8 +69,16 @@ public class Reservation extends BaseTimeEntity {
 			.build();
 	}
 
-	public void updateStatus(ReservationStatus status) {
-		this.status = status;
+	public void confirmReservation() {
+		this.status = ReservationStatus.CONFIRMED;
+	}
+
+	public void enterReservation() {
+		this.status = ReservationStatus.ENTERED;
+	}
+
+	public void cancelReservation() {
+		this.status = ReservationStatus.CANCELLED;
 	}
 
 }

--- a/src/main/java/com/goorm/ticker/reservation/Entity/ReservationStatus.java
+++ b/src/main/java/com/goorm/ticker/reservation/Entity/ReservationStatus.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 @JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum ReservationStatus {
-	WAITING, CONFIRMED, CANCELLED, COMPLETED
+	PENDING, CONFIRMED, ENTERED, CANCELLED
 }

--- a/src/main/java/com/goorm/ticker/restaurant/entity/ReservationPolicy.java
+++ b/src/main/java/com/goorm/ticker/restaurant/entity/ReservationPolicy.java
@@ -1,0 +1,8 @@
+package com.goorm.ticker.restaurant.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum ReservationPolicy {
+	INSTANT_CONFIRMATION, MANUAL_CONFIRMATION
+}

--- a/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
@@ -2,6 +2,8 @@ package com.goorm.ticker.restaurant.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -36,6 +38,7 @@ public class Restaurant {
 	@Column(name = "max_waiting", nullable = false)
 	private Integer maxWaiting;
 
+	@Enumerated(EnumType.STRING)
 	@Column(name = "reservation_policy", nullable = false)
 	private ReservationPolicy reservation_policy;
 

--- a/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
@@ -40,7 +40,7 @@ public class Restaurant {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "reservation_policy", nullable = false)
-	private ReservationPolicy reservation_policy;
+	private ReservationPolicy reservationPolicy;
 
 	public static Restaurant of(String restaurantName, String x, String y, Integer maxWaiting,
 		ReservationPolicy reservationPolicy) {
@@ -49,7 +49,7 @@ public class Restaurant {
 			.x(x)
 			.y(y)
 			.maxWaiting(maxWaiting)
-			.reservation_policy(reservationPolicy)
+			.reservationPolicy(reservationPolicy)
 			.build();
 	}
 }

--- a/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/goorm/ticker/restaurant/entity/Restaurant.java
@@ -36,12 +36,17 @@ public class Restaurant {
 	@Column(name = "max_waiting", nullable = false)
 	private Integer maxWaiting;
 
-	public static Restaurant of(String restaurantName, String x, String y, Integer maxWaiting) {
+	@Column(name = "reservation_policy", nullable = false)
+	private ReservationPolicy reservation_policy;
+
+	public static Restaurant of(String restaurantName, String x, String y, Integer maxWaiting,
+		ReservationPolicy reservationPolicy) {
 		return Restaurant.builder()
 			.restaurantName(restaurantName)
 			.x(x)
 			.y(y)
 			.maxWaiting(maxWaiting)
+			.reservation_policy(reservationPolicy)
 			.build();
 	}
 }

--- a/src/main/java/com/goorm/ticker/restaurant/repository/ReservationSlotRepository.java
+++ b/src/main/java/com/goorm/ticker/restaurant/repository/ReservationSlotRepository.java
@@ -4,13 +4,17 @@ import java.time.LocalTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.goorm.ticker.restaurant.entity.ReservationSlot;
 
+import jakarta.persistence.LockModeType;
+
 public interface ReservationSlotRepository extends JpaRepository<ReservationSlot, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT r FROM ReservationSlot r WHERE r.slotTime = :slotTime AND r.restaurant.restaurantId = :restaurantId")
-	Optional<ReservationSlot> findBySlotTimeAndRestaurantId(@Param("slotTime") LocalTime slotTime,
+	Optional<ReservationSlot> findBySlotTimeAndRestaurantIdWithLock(@Param("slotTime") LocalTime slotTime,
 		@Param("restaurantId") Long restaurantId);
 }

--- a/src/test/java/com/goorm/ticker/fixture/ReservationFixture.java
+++ b/src/test/java/com/goorm/ticker/fixture/ReservationFixture.java
@@ -12,7 +12,7 @@ public enum ReservationFixture {
 	RESERVATION_FIXTURE_1(
 		4,
 		LocalDate.of(2025, 2, 22),
-		ReservationStatus.WAITING
+		ReservationStatus.PENDING
 	),
 	RESERVATION_FIXTURE_2(
 		2,
@@ -27,7 +27,7 @@ public enum ReservationFixture {
 	RESERVATION_FIXTURE_4(
 		2,
 		LocalDate.of(2025, 2, 22),
-		ReservationStatus.COMPLETED
+		ReservationStatus.ENTERED
 	);
 
 	private final Integer partySize;

--- a/src/test/java/com/goorm/ticker/fixture/RestaurantFixture.java
+++ b/src/test/java/com/goorm/ticker/fixture/RestaurantFixture.java
@@ -1,5 +1,6 @@
 package com.goorm.ticker.fixture;
 
+import com.goorm.ticker.restaurant.entity.ReservationPolicy;
 import com.goorm.ticker.restaurant.entity.Restaurant;
 
 public enum RestaurantFixture {
@@ -7,27 +8,32 @@ public enum RestaurantFixture {
 		"Test Restaurant 1",
 		"37.5665",
 		"126.9780",
-		50),
+		50,
+		ReservationPolicy.INSTANT_CONFIRMATION),
 	RESTAURANT_FIXTURE_2(
 		"Test Restaurant 2",
 		"37.5675",
 		"126.9790",
-		30);
+		30,
+		ReservationPolicy.MANUAL_CONFIRMATION);
 
 	private final String name;
 	private final String x;
 	private final String y;
 	private final Integer maxWaiting;
+	private final ReservationPolicy reservationPolicy;
 
-	RestaurantFixture(String name, String x, String y, Integer maxWaiting) {
+	RestaurantFixture(String name, String x, String y, Integer maxWaiting,
+		ReservationPolicy reservationPolicy) {
 		this.name = name;
 		this.x = x;
 		this.y = y;
 		this.maxWaiting = maxWaiting;
+		this.reservationPolicy = reservationPolicy;
 	}
 
 	public Restaurant createRestaurant() {
-		return Restaurant.of(name, x, y, maxWaiting);
+		return Restaurant.of(name, x, y, maxWaiting, reservationPolicy);
 	}
 
 }

--- a/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
@@ -99,7 +99,7 @@ public class ReservationConcurrencyTest {
 	}
 
 	@Test
-	@DisplayName("100명 유저 동시 예약 테스트")
+	@DisplayName("100명 유저 동시 예약 테스트 - 비관적 락 적용")
 	void testConcurrentReservationsWithoutLock() throws InterruptedException {
 		ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
 		CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
@@ -128,11 +128,12 @@ public class ReservationConcurrencyTest {
 						partySize);
 					reservationService.reserve(request);
 					successCount.incrementAndGet();
-					log.info("[O] 예약 성공 - 유저 ID: {} | 예약 일시 : {} {}", (index), reservationDate,
+					log.info("[O] 성공 - 유저 ID: {} | 예약 일시 : {} {}", (index), reservationDate,
 						reservationTime);
 				} catch (CustomException e) {
 					failureCount.incrementAndGet();
-					log.warn("[X] 예약 실패 - 유저 ID: {} | 에러 코드: {}", (index), e.getErrorCode());
+					log.warn("[X] 실패 - 유저 ID: {} | 에러 코드: {} | {} ", (index), e.getErrorCode(),
+						e.getErrorCode().getMessage());
 				} finally {
 					latch.countDown();
 				}
@@ -144,7 +145,7 @@ public class ReservationConcurrencyTest {
 		log.info("--------------------------------------------");
 		long endTime = System.currentTimeMillis();
 
-		log.info("비관적 락 실행 시간: {} ms", (endTime - startTime));
+		log.info("실행 시간: {} ms", (endTime - startTime));
 		log.info("예약 성공: {}", successCount.get());
 		log.warn("예약 실패: {}", failureCount.get());
 

--- a/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.fixture.ReservationSlotFixture;
@@ -33,6 +34,7 @@ import com.goorm.ticker.user.repository.UserRepository;
 
 import lombok.extern.slf4j.Slf4j;
 
+@ActiveProfiles("test")
 @Slf4j
 @SpringBootTest
 public class ReservationConcurrencyTest {
@@ -115,7 +117,7 @@ public class ReservationConcurrencyTest {
 		log.info("테스트 시작 - 100명의 유저가 동시에 예약 요청을 보냅니다.");
 		log.info("-----------------------------------------------------");
 		int partySize = 2;
-		for (long i = startUserId; i <= startUserId + THREAD_COUNT; i++) {
+		for (long i = startUserId; i < startUserId + THREAD_COUNT; i++) {
 			final long index = i;
 			executorService.execute(() -> {
 				try {

--- a/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
@@ -1,0 +1,155 @@
+package com.goorm.ticker.reservation.integration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.goorm.ticker.common.exception.CustomException;
+import com.goorm.ticker.fixture.ReservationSlotFixture;
+import com.goorm.ticker.fixture.RestaurantFixture;
+import com.goorm.ticker.reservation.dto.request.ReservationCreateRequest;
+import com.goorm.ticker.reservation.repository.ReservationRepository;
+import com.goorm.ticker.reservation.service.ReservationService;
+import com.goorm.ticker.restaurant.entity.ReservationSlot;
+import com.goorm.ticker.restaurant.entity.Restaurant;
+import com.goorm.ticker.restaurant.repository.ReservationSlotRepository;
+import com.goorm.ticker.restaurant.repository.RestaurantRepository;
+import com.goorm.ticker.user.entity.User;
+import com.goorm.ticker.user.repository.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest
+public class ReservationConcurrencyTest {
+
+	private static final int THREAD_COUNT = 1000;
+
+	@Autowired
+	private ReservationService reservationService;
+
+	@Autowired
+	private RestaurantRepository restaurantRepository;
+
+	@Autowired
+	private ReservationSlotRepository reservationSlotRepository;
+
+	@Autowired
+	private ReservationRepository reservationRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private Restaurant restaurantInstant;
+
+	private List<ReservationSlot> testSlots = new ArrayList<>();
+
+	@BeforeEach
+	void setUp() {
+		// 테스트용 음식점 저장
+		restaurantInstant = restaurantRepository.save(RestaurantFixture.RESTAURANT_FIXTURE_1.createRestaurant());
+
+		// 테스트용 예약 슬롯 저장
+		for (ReservationSlotFixture slotFixture : ReservationSlotFixture.values()) {
+			ReservationSlot slot = slotFixture.createSlot(restaurantInstant);
+			reservationSlotRepository.save(slot);
+			testSlots.add(slot);
+		}
+		for (int i = 0; i < THREAD_COUNT; i++) {
+			User user = User.builder()
+				.loginId("loginId" + (i))
+				.name("name" + (i))
+				.password("password" + (i))
+				.build();
+
+			userRepository.save(user);
+		}
+		userRepository.flush();
+
+		// 데이터 검증
+		assertThat(restaurantRepository.count()).isGreaterThan(0);
+		assertThat(reservationSlotRepository.count()).isGreaterThanOrEqualTo(4);
+		assertThat(userRepository.count()).isEqualTo(THREAD_COUNT);
+	}
+
+	@AfterEach
+	void afterEach() {
+		reservationRepository.deleteAll();
+		reservationSlotRepository.deleteAll();
+		restaurantRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("1000명 유저 동시 예약 테스트")
+	void testConcurrentReservationsWithoutLock() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+		CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+		long startTime = System.currentTimeMillis();
+		Long restaurantId = restaurantInstant.getRestaurantId();
+		LocalTime reservationTime = LocalTime.of(12, 0);
+		LocalDate reservationDate = LocalDate.now();
+
+		AtomicInteger successCount = new AtomicInteger(0); // 성공한 예약 수
+		AtomicInteger failureCount = new AtomicInteger(0); // 실패한 예약 수
+		log.info("🔄restaurantId : {}", restaurantId);
+		log.info("🔄reservationTime : {}", reservationTime);
+		log.info("🔄reservationDate : {}", reservationDate);
+		log.info("🔄 테스트 시작 - 100명의 유저가 동시에 예약 요청을 보냅니다.");
+		int partySize = 2;
+		for (long i = 1; i <= THREAD_COUNT; i++) {
+			final long index = i;
+			executorService.execute(() -> {
+				try {
+					ReservationCreateRequest request = ReservationCreateRequest.of(
+						(index),
+						restaurantId,
+						reservationTime,
+						reservationDate,
+						partySize);
+					reservationService.reserve(request);
+					successCount.incrementAndGet();
+					log.info("[O] 예약 성공 - 유저 ID: {} | 예약 일시 : {} {}", (index), reservationDate,
+						reservationTime);
+				} catch (CustomException e) {
+					failureCount.incrementAndGet();
+					log.warn("[X] 예약 실패 - 유저 ID: {} | 에러 코드: {}", (index), e.getErrorCode());
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executorService.shutdown();
+		log.info("--------------------------------------------");
+		log.info("예약 성공: {}", successCount.get());
+		log.warn("예약 실패: {}", failureCount.get());
+
+		long endTime = System.currentTimeMillis(); // 실행 시간 측정 종료
+
+		log.info("비관적 락 실행 시간: {} ms", (endTime - startTime));
+
+		// DB에서 실제 예약된 건수 확인
+		long totalReservations = reservationRepository.count();
+		log.info("실제 DB 예약 건수: {}", totalReservations);
+
+		// // 예약 가능한 슬롯보다 더 많은 예약이 들어가면 안 됨
+		assertThat(successCount.get()).isEqualTo(testSlots.get(0).getAvailablePartySize() / partySize);
+		assertThat(totalReservations).isEqualTo(testSlots.get(0).getAvailablePartySize() / partySize);
+	}
+}

--- a/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @SpringBootTest
 public class ReservationConcurrencyTest {
 
-	private static final int THREAD_COUNT = 1000;
+	private static final int THREAD_COUNT = 100;
 
 	@Autowired
 	private ReservationService reservationService;
@@ -98,7 +98,7 @@ public class ReservationConcurrencyTest {
 	}
 
 	@Test
-	@DisplayName("1000명 유저 동시 예약 테스트")
+	@DisplayName("100명 유저 동시 예약 테스트")
 	void testConcurrentReservationsWithoutLock() throws InterruptedException {
 		ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
 		CountDownLatch latch = new CountDownLatch(THREAD_COUNT);

--- a/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
@@ -71,20 +71,19 @@ public class ReservationConcurrencyTest {
 			reservationSlotRepository.save(slot);
 			testSlots.add(slot);
 		}
+		List<User> users = new ArrayList<>();
 		for (int i = 0; i < THREAD_COUNT; i++) {
-			User user = User.builder()
+			users.add(User.builder()
 				.loginId("loginId" + (i))
 				.name("name" + (i))
 				.password("password" + (i))
-				.build();
-
-			User savedUser = userRepository.save(user);
-			if (i == 0) {
-				startUserId = savedUser.getId();
-			}
+				.build());
 		}
+		List<User> savedUsers = userRepository.saveAll(users);
 		userRepository.flush();
 
+		// 시작 ID 설정
+		startUserId = savedUsers.get(0).getId();
 		// 데이터 검증
 		assertThat(restaurantRepository.count()).isGreaterThan(0);
 		assertThat(reservationSlotRepository.count()).isGreaterThanOrEqualTo(4);

--- a/src/test/java/com/goorm/ticker/reservation/integration/UserDummyDataTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/UserDummyDataTest.java
@@ -1,0 +1,77 @@
+package com.goorm.ticker.reservation.integration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.goorm.ticker.user.entity.User;
+import com.goorm.ticker.user.repository.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ActiveProfiles("test")
+@Slf4j
+@SpringBootTest
+public class UserDummyDataTest {
+
+	private static final int THREAD_COUNT = 100;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@AfterEach
+	void cleanUp() {
+		userRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("user 더미데이터 생성 -> 개별 save() 사용 성능 테스트")
+	void testIndividualSavePerformance() {
+		long startTime = System.currentTimeMillis();
+
+		for (int i = 0; i < THREAD_COUNT; i++) {
+			User user = User.builder()
+				.loginId("loginId" + i)
+				.name("name" + i)
+				.password("password" + i)
+				.build();
+			userRepository.save(user);
+		}
+
+		userRepository.flush(); // ID 할당 보장
+		long endTime = System.currentTimeMillis();
+
+		log.info("개별 save() 실행 시간: {} ms", (endTime - startTime));
+		assertThat(userRepository.count()).isEqualTo(THREAD_COUNT);
+	}
+
+	@Test
+	@DisplayName("user 더미데이터 생성 ->  saveAll() 사용 성능 테스트")
+	void testSaveAllPerformance() {
+		long startTime = System.currentTimeMillis();
+
+		List<User> users = new ArrayList<>();
+		for (int i = 0; i < THREAD_COUNT; i++) {
+			users.add(User.builder()
+				.loginId("loginId" + i)
+				.name("name" + i)
+				.password("password" + i)
+				.build());
+		}
+
+		userRepository.saveAll(users);
+		userRepository.flush(); // ID 할당 보장
+		long endTime = System.currentTimeMillis();
+
+		log.info("saveAll() 실행 시간: {} ms", (endTime - startTime));
+		assertThat(userRepository.count()).isEqualTo(THREAD_COUNT);
+	}
+}

--- a/src/test/java/com/goorm/ticker/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/service/ReservationServiceTest.java
@@ -268,7 +268,7 @@ class ReservationServiceTest {
 		Long reservationId = reservationManual.getReservationId();
 
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservationManual));
-		
+
 		int initialAvailablePartySize = reservationSlotManual.getAvailablePartySize();
 		// When
 		ReservationCreateResponse response = reservationService.updateReservation(reservationId, "CANCELLED");

--- a/src/test/java/com/goorm/ticker/waitlist/controller/WaitListControllerTest.java
+++ b/src/test/java/com/goorm/ticker/waitlist/controller/WaitListControllerTest.java
@@ -1,15 +1,12 @@
 package com.goorm.ticker.waitlist.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.goorm.ticker.restaurant.entity.Restaurant;
-import com.goorm.ticker.restaurant.repository.RestaurantRepository;
-import com.goorm.ticker.user.entity.User;
-import com.goorm.ticker.user.repository.UserRepository;
-import com.goorm.ticker.waitlist.dto.WaitListRequestDto;
-import com.goorm.ticker.waitlist.entity.Status;
-import com.goorm.ticker.waitlist.entity.WaitList;
-import com.goorm.ticker.waitlist.repository.WaitListRepository;
-import org.junit.jupiter.api.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,315 +17,325 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.ticker.restaurant.entity.ReservationPolicy;
+import com.goorm.ticker.restaurant.entity.Restaurant;
+import com.goorm.ticker.restaurant.repository.RestaurantRepository;
+import com.goorm.ticker.user.entity.User;
+import com.goorm.ticker.user.repository.UserRepository;
+import com.goorm.ticker.waitlist.dto.WaitListRequestDto;
+import com.goorm.ticker.waitlist.entity.Status;
+import com.goorm.ticker.waitlist.entity.WaitList;
+import com.goorm.ticker.waitlist.repository.WaitListRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 public class WaitListControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+	@Autowired
+	private ObjectMapper objectMapper;
 
-    @Autowired
-    WaitListRepository waitListRepository;
+	@Autowired
+	WaitListRepository waitListRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+	@Autowired
+	private UserRepository userRepository;
 
-    @Autowired
-    private RestaurantRepository restaurantRepository;
+	@Autowired
+	private RestaurantRepository restaurantRepository;
 
-    private MockHttpSession session;
-    private Long testRestaurantId;
+	private MockHttpSession session;
+	private Long testRestaurantId;
 
-    @BeforeEach
-    void setUp() {
-        session = new MockHttpSession();
+	@BeforeEach
+	void setUp() {
+		session = new MockHttpSession();
 
-        User testUser = userRepository.save(User.builder()
-                .loginId("testId")
-                .name("testName")
-                .password("testPassword")
-                .build());
+		User testUser = userRepository.save(User.builder()
+			.loginId("testId")
+			.name("testName")
+			.password("testPassword")
+			.build());
 
-        Restaurant restaurant = restaurantRepository.save(Restaurant.builder()
-                .restaurantName("test")
-                .x("testX")
-                .y("testY")
-                .maxWaiting(10)
-                .build());
+		Restaurant restaurant = restaurantRepository.save(Restaurant.builder()
+			.restaurantName("test")
+			.x("testX")
+			.y("testY")
+			.maxWaiting(10)
+			.reservationPolicy(ReservationPolicy.INSTANT_CONFIRMATION)
+			.build());
 
-        testRestaurantId = restaurant.getRestaurantId();
-        session.setAttribute("user", testUser.getId());
-    }
+		testRestaurantId = restaurant.getRestaurantId();
+		session.setAttribute("user", testUser.getId());
+	}
 
-    @AfterEach
-    void afterEach() {
-        waitListRepository.deleteAll();
-        userRepository.deleteAll();
-        restaurantRepository.deleteAll();
-    }
+	@AfterEach
+	void afterEach() {
+		waitListRepository.deleteAll();
+		userRepository.deleteAll();
+		restaurantRepository.deleteAll();
+	}
 
-    @Test
-    @DisplayName("대기열 등록 성공 - 200 반환")
-    void registerWaiting_Success() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("대기열 등록 성공 - 200 반환")
+	void registerWaiting_Success() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+	}
 
-    @Test
-    @DisplayName("대기열 등록 실패 - 세션 없음 (401 Unauthorized)")
-    void registerWaiting_Fail_NoSession() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("대기열 등록 실패 - 세션 없음 (401 Unauthorized)")
+	void registerWaiting_Fail_NoSession() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
 
-    @Test
-    @DisplayName("대기열 등록 실패 - 존재하지 않는 식당 (404 Not Found)")
-    void registerWaiting_Fail_InvalidRestaurant() throws Exception {
-        Long invalidRestaurantId = 9999L;
+	@Test
+	@DisplayName("대기열 등록 실패 - 존재하지 않는 식당 (404 Not Found)")
+	void registerWaiting_Fail_InvalidRestaurant() throws Exception {
+		Long invalidRestaurantId = 9999L;
 
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(invalidRestaurantId)
-                .build();
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(invalidRestaurantId)
+			.build();
 
-        MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+	}
 
-    @Test
-    @DisplayName("대기열 등록 실패 - 이미 같은 식당에 대기 중 (400 Bad Request)")
-    void registerWaiting_Fail_AlreadyWaiting() throws Exception {
-        User user = userRepository.findAll().get(0);
-        Restaurant restaurant = restaurantRepository.findAll().get(0);
+	@Test
+	@DisplayName("대기열 등록 실패 - 이미 같은 식당에 대기 중 (400 Bad Request)")
+	void registerWaiting_Fail_AlreadyWaiting() throws Exception {
+		User user = userRepository.findAll().get(0);
+		Restaurant restaurant = restaurantRepository.findAll().get(0);
 
-        waitListRepository.save(WaitList.builder()
-                .user(user)
-                .restaurant(restaurant)
-                .waitingNumber(1)
-                .status(Status.WAITING)
-                .build());
+		waitListRepository.save(WaitList.builder()
+			.user(user)
+			.restaurant(restaurant)
+			.waitingNumber(1)
+			.status(Status.WAITING)
+			.build());
 
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(post("/waitlist")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
 
-    @Test
-    @DisplayName("대기 순번 조회 성공 - 200 반환")
-    void getUserWaiting_Success() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("대기 순번 조회 성공 - 200 반환")
+	void getUserWaiting_Success() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        mockMvc.perform(post("/waitlist")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session));
+		mockMvc.perform(post("/waitlist")
+			.content(objectMapper.writeValueAsString(request))
+			.contentType(MediaType.APPLICATION_JSON)
+			.session(session));
 
-        MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", testRestaurantId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", testRestaurantId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+	}
 
-    @Test
-    @DisplayName("대기 순번 조회 실패 - 세션 없음 (401 Unauthorized)")
-    void getUserWaiting_Fail_NoSession() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("대기 순번 조회 실패 - 세션 없음 (401 Unauthorized)")
+	void getUserWaiting_Fail_NoSession() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        mockMvc.perform(post("/waitlist")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON)
-                .session(session));
+		mockMvc.perform(post("/waitlist")
+			.content(objectMapper.writeValueAsString(request))
+			.contentType(MediaType.APPLICATION_JSON)
+			.session(session));
 
-        MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", testRestaurantId)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", testRestaurantId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
 
-    @Test
-    @DisplayName("대기 순번 조회 실패 - 잘못된 식당 ID (404 Not Found)")
-    void getUserWaiting_Fail_InvalidRestaurantId() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("대기 순번 조회 실패 - 잘못된 식당 ID (404 Not Found)")
+	void getUserWaiting_Fail_InvalidRestaurantId() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        mockMvc.perform(post("/waitlist")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON)
-                .session(session));
+		mockMvc.perform(post("/waitlist")
+			.content(objectMapper.writeValueAsString(request))
+			.contentType(MediaType.APPLICATION_JSON)
+			.session(session));
 
-        MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", 9999L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", 9999L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+	}
 
-    @Test
-    @DisplayName("대기 순번 조회 실패 - 대기열의 없는 사용자 (404 Not Found)")
-    void getUserWaiting_Fail_UserNotWaitingList() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", testRestaurantId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+	@Test
+	@DisplayName("대기 순번 조회 실패 - 대기열의 없는 사용자 (404 Not Found)")
+	void getUserWaiting_Fail_UserNotWaitingList() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/position", testRestaurantId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+	}
 
-    @Test
-    @DisplayName("총 대기인원 조회 성공 - 200 반환")
-    void getWaitingPosition_Success() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get("/waitlist/{restaurantId}/totalWaiting", testRestaurantId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+	@Test
+	@DisplayName("총 대기인원 조회 성공 - 200 반환")
+	void getWaitingPosition_Success() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(
+				get("/waitlist/{restaurantId}/totalWaiting", testRestaurantId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+	}
 
-    @Test
-    @DisplayName("입장 완료 성공 - 200 반환")
-    void completeWaiting_Success() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("입장 완료 성공 - 200 반환")
+	void completeWaiting_Success() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        mockMvc.perform(post("/waitlist")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON)
-                .session(session));
+		mockMvc.perform(post("/waitlist")
+			.content(objectMapper.writeValueAsString(request))
+			.contentType(MediaType.APPLICATION_JSON)
+			.session(session));
 
-        MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/complete")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/complete")
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo("식당 입장 완료되었습니다.");
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+		assertThat(response.getContentAsString()).isEqualTo("식당 입장 완료되었습니다.");
+	}
 
-    @Test
-    @DisplayName("입장 완료 실패 - 세션 없음 (401 Unauthorized)")
-    void completeWaiting_Fail_NoSession() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("입장 완료 실패 - 세션 없음 (401 Unauthorized)")
+	void completeWaiting_Fail_NoSession() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        mockMvc.perform(post("/waitlist")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON)
-                .session(session));
+		mockMvc.perform(post("/waitlist")
+			.content(objectMapper.writeValueAsString(request))
+			.contentType(MediaType.APPLICATION_JSON)
+			.session(session));
 
-        MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/complete")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/complete")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
 
-    @Test
-    @DisplayName("입장 완료 실패 - 대기열의 없는 사용자 (404 Not Found)")
-    void completeWaiting_Fail_UserNotInWaitingList() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/complete")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+	@Test
+	@DisplayName("입장 완료 실패 - 대기열의 없는 사용자 (404 Not Found)")
+	void completeWaiting_Fail_UserNotInWaitingList() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/complete")
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+	}
 
-    @Test
-    @DisplayName("대기 취소 성공 - 200 반환")
-    void cancelWaiting_Success() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("대기 취소 성공 - 200 반환")
+	void cancelWaiting_Success() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        mockMvc.perform(post("/waitlist")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON)
-                .session(session));
+		mockMvc.perform(post("/waitlist")
+			.content(objectMapper.writeValueAsString(request))
+			.contentType(MediaType.APPLICATION_JSON)
+			.session(session));
 
-        MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/cancel")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/cancel")
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getContentAsString()).isEqualTo("대기열이 취소되었습니다.");
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+		assertThat(response.getContentAsString()).isEqualTo("대기열이 취소되었습니다.");
+	}
 
-    @Test
-    @DisplayName("대기 취소 실패 - 세션 없음 (401 Unauthorized)")
-    void cancelWaiting_Fail_NoSession() throws Exception {
-        WaitListRequestDto request = WaitListRequestDto.builder()
-                .restaurantId(testRestaurantId)
-                .build();
+	@Test
+	@DisplayName("대기 취소 실패 - 세션 없음 (401 Unauthorized)")
+	void cancelWaiting_Fail_NoSession() throws Exception {
+		WaitListRequestDto request = WaitListRequestDto.builder()
+			.restaurantId(testRestaurantId)
+			.build();
 
-        mockMvc.perform(post("/waitlist")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON)
-                .session(session));
+		mockMvc.perform(post("/waitlist")
+			.content(objectMapper.writeValueAsString(request))
+			.contentType(MediaType.APPLICATION_JSON)
+			.session(session));
 
-        MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/cancel")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/cancel")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
 
-    @Test
-    @DisplayName("대기 취소 실패 - 대기열에 없는 사용자 (404 Not Found)")
-    void cancelWaiting_Fail_UserNotInWaitingList() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/cancel")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .session(session))
-                .andReturn().getResponse();
+	@Test
+	@DisplayName("대기 취소 실패 - 대기열에 없는 사용자 (404 Not Found)")
+	void cancelWaiting_Fail_UserNotInWaitingList() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(patch("/waitlist/cancel")
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    }
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+	}
 }


### PR DESCRIPTION
## **PR 타입 (하나 이상의 PR 타입을 선택해주세요)**

- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## **반영 브랜치**
- `feature/#3 -> dev`


## **이슈**
- #19 


## **작업 사항**
- ReservationPolicy Enum 생성
- Restaurant 엔티티에 예약 정책 필드 추가
- ReservationStatus Enum 변경
- reserve() 메서드 수정
   - INSTANT_CONFIRMATION: 요청 즉시 예약 상태를 CONFIRMED로 설정하고, availablePartySize를 감소.
   - MANUAL_CONFIRMATION: 요청 시 예약 상태를 PENDING으로 저장.
   - 비관적 lock 적용
- test 코드 내 오류 수저
- 기존 예약 테스트 수정
- 100명 동시 예약 시도 테스트 진행.

## 리뷰어에게 전달 사항
- 현재 1000명의 유저의 동시 예약 시도에 대해서 테스트를 진행해보았는데 피드백 부탁드립니다.