### PR TITLE
Feature/#3 예약 취소/생성 테스트

### DIFF
--- a/src/main/java/com/goorm/ticker/common/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/ticker/common/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
 	PARTY_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "해당 시간대에 예약 가능한 인원이 초과되었습니다."),
 	RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
 	RESERVATION_ALREADY_UPDATED(HttpStatus.BAD_REQUEST, "이미 처리한 예약입니다."),
-	INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "존재하지 않는 예약 상태입니다."),
+	INVALID_RESERVATION_STATUS(HttpStatus.NOT_FOUND, "존재하지 않는 예약 상태입니다."),
+	UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.UNAUTHORIZED, "해당 예약에 접근할 수 없습니다."),
 
 	// WaitList
 	WAITLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 대기열을 찾을 수 없습니다."),

--- a/src/main/java/com/goorm/ticker/common/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/ticker/common/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 	RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
 	RESERVATION_ALREADY_UPDATED(HttpStatus.BAD_REQUEST, "이미 처리한 예약입니다."),
 	INVALID_RESERVATION_STATUS(HttpStatus.NOT_FOUND, "존재하지 않는 예약 상태입니다."),
-	UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.UNAUTHORIZED, "해당 예약에 접근할 수 없습니다."),
+	FORBIDDEN_RESERVATION_ACCESS(HttpStatus.FORBIDDEN, "해당 예약에 접근할 수 없습니다."),
 
 	// WaitList
 	WAITLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 대기열을 찾을 수 없습니다."),

--- a/src/main/java/com/goorm/ticker/reservation/controller/ReservationController.java
+++ b/src/main/java/com/goorm/ticker/reservation/controller/ReservationController.java
@@ -10,10 +10,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goorm.ticker.common.exception.CustomException;
+import com.goorm.ticker.common.exception.ErrorCode;
 import com.goorm.ticker.reservation.dto.request.ReservationCreateRequest;
 import com.goorm.ticker.reservation.dto.response.ReservationCreateResponse;
 import com.goorm.ticker.reservation.service.ReservationService;
 
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -25,17 +28,30 @@ public class ReservationController {
 
 	@PostMapping
 	public ResponseEntity<ReservationCreateResponse> createReservation(
-		@Valid @RequestBody ReservationCreateRequest request) {
-		ReservationCreateResponse response = reservationService.reserve(request);
+		@Valid @RequestBody ReservationCreateRequest request,
+		HttpSession httpSession) {
+		Long userId = (Long)httpSession.getAttribute("userId");
+
+		if (userId == null) {
+			throw new CustomException(ErrorCode.SESSION_EXPIRED);
+		}
+
+		ReservationCreateResponse response = reservationService.reserve(request, userId);
 		return ResponseEntity.ok(response);
 	}
 
 	@PatchMapping("/{reservationId}")
 	public ResponseEntity<ReservationCreateResponse> updateReservation(
 		@PathVariable Long reservationId,
-		@RequestBody Map<String, String> updateRequest) {
+		@RequestBody Map<String, String> updateRequest,
+		HttpSession httpSession) {
 		String status = updateRequest.get("status");
-		ReservationCreateResponse response = reservationService.updateReservation(reservationId, status);
+
+		Long userId = (Long)httpSession.getAttribute("userId");
+		if (userId == null) {
+			throw new CustomException(ErrorCode.SESSION_EXPIRED);
+		}
+		ReservationCreateResponse response = reservationService.updateReservation(reservationId, status, userId);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/goorm/ticker/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/goorm/ticker/reservation/repository/ReservationRepository.java
@@ -3,6 +3,8 @@ package com.goorm.ticker.reservation.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goorm.ticker.reservation.Entity.Reservation;
+import com.goorm.ticker.reservation.Entity.ReservationStatus;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+	long countByStatus(ReservationStatus status);
 }

--- a/src/main/java/com/goorm/ticker/reservation/service/ReservationService.java
+++ b/src/main/java/com/goorm/ticker/reservation/service/ReservationService.java
@@ -63,7 +63,7 @@ public class ReservationService {
 		);
 
 		if (restaurant.getReservationPolicy() == ReservationPolicy.INSTANT_CONFIRMATION) {
-			slot.updateAvailablePartySize(slot.getAvailablePartySize() - request.getPartySize());
+			reservationSlotRepository.decreaseAvailablePartySize(slot.getId(), request.getPartySize());
 		}
 
 		reservationRepository.save(reservation);
@@ -123,8 +123,9 @@ public class ReservationService {
 
 	private void handleCancellation(Reservation reservation) {
 		if (reservation.getStatus() == ReservationStatus.CONFIRMED) {
-			ReservationSlot slot = reservation.getReservationSlot();
-			slot.updateAvailablePartySize(slot.getAvailablePartySize() + reservation.getPartySize());
+			// 원자적으로 가용 인원 증가 (비관적 락 적용된 트랜잭션 내에서 실행됨)
+			reservationSlotRepository.increaseAvailablePartySize(reservation.getReservationSlot().getId(),
+				reservation.getPartySize());
 		}
 		reservation.cancelReservation();
 	}

--- a/src/main/java/com/goorm/ticker/reservation/service/ReservationService.java
+++ b/src/main/java/com/goorm/ticker/reservation/service/ReservationService.java
@@ -29,7 +29,7 @@ public class ReservationService {
 	private final UserRepository userRepository;
 
 	@Transactional
-	public ReservationCreateResponse reserve(ReservationCreateRequest request) {
+	public ReservationCreateResponse reserve(ReservationCreateRequest request, Long userId) {
 
 		// 음식점 조회
 		Restaurant restaurant = restaurantRepository.findById(request.getRestaurantId())
@@ -45,7 +45,7 @@ public class ReservationService {
 			throw new CustomException(ErrorCode.PARTY_SIZE_EXCEEDED);
 		}
 
-		User user = userRepository.findById(request.getUserId())
+		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
 		ReservationStatus initialStatus = switch (restaurant.getReservationPolicy()) {
@@ -80,10 +80,14 @@ public class ReservationService {
 	}
 
 	@Transactional
-	public ReservationCreateResponse updateReservation(Long reservationId, String status) {
+	public ReservationCreateResponse updateReservation(Long reservationId, String status, Long userId) {
 		// 예약 조회
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+		if (!reservation.getUser().getId().equals(userId)) {
+			throw new CustomException(ErrorCode.FORBIDDEN_RESERVATION_ACCESS);
+		}
 
 		// 예약 상태 확인
 		ReservationStatus newStatus;

--- a/src/main/java/com/goorm/ticker/reservation/service/ReservationService.java
+++ b/src/main/java/com/goorm/ticker/reservation/service/ReservationService.java
@@ -19,9 +19,11 @@ import com.goorm.ticker.user.entity.User;
 import com.goorm.ticker.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReservationService {
 	private final ReservationRepository reservationRepository;
 	private final RestaurantRepository restaurantRepository;
@@ -63,10 +65,15 @@ public class ReservationService {
 		);
 
 		if (restaurant.getReservationPolicy() == ReservationPolicy.INSTANT_CONFIRMATION) {
+			// 원자적으로 가용 인원 감소
 			reservationSlotRepository.decreaseAvailablePartySize(slot.getId(), request.getPartySize());
 		}
 
 		reservationRepository.save(reservation);
+
+		log.info("[O] 예약 성공 - 유저 ID: {} | 예약 ID: {} | 남은 예약 가능 인원: {}",
+			reservation.getUser().getId(), reservation.getReservationId(),
+			reservation.getReservationSlot().getAvailablePartySize());
 
 		return ReservationCreateResponse.builder()
 			.reservationId(reservation.getReservationId())
@@ -123,11 +130,15 @@ public class ReservationService {
 
 	private void handleCancellation(Reservation reservation) {
 		if (reservation.getStatus() == ReservationStatus.CONFIRMED) {
-			// 원자적으로 가용 인원 증가 (비관적 락 적용된 트랜잭션 내에서 실행됨)
+			// 원자적으로 가용 인원 증가
 			reservationSlotRepository.increaseAvailablePartySize(reservation.getReservationSlot().getId(),
 				reservation.getPartySize());
 		}
 		reservation.cancelReservation();
+		log.info("[O] 취소 성공 - 유저 ID: {} | 예약 ID: {} | 남은 예약 가능 인원: {}",
+			reservation.getUser().getId(), reservation.getReservationId(),
+			reservation.getReservationSlot().getAvailablePartySize());
+
 	}
 
 	private void handleEntry(Reservation reservation) {

--- a/src/main/java/com/goorm/ticker/restaurant/repository/ReservationSlotRepository.java
+++ b/src/main/java/com/goorm/ticker/restaurant/repository/ReservationSlotRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +18,14 @@ public interface ReservationSlotRepository extends JpaRepository<ReservationSlot
 	@Query("SELECT r FROM ReservationSlot r WHERE r.slotTime = :slotTime AND r.restaurant.restaurantId = :restaurantId")
 	Optional<ReservationSlot> findBySlotTimeAndRestaurantIdWithLock(@Param("slotTime") LocalTime slotTime,
 		@Param("restaurantId") Long restaurantId);
+
+	@Modifying
+	@Query("UPDATE ReservationSlot rs SET rs.availablePartySize = rs.availablePartySize - :partySize " +
+		"WHERE rs.id = :slotId AND rs.availablePartySize >= :partySize")
+	int decreaseAvailablePartySize(@Param("slotId") Long slotId, @Param("partySize") int partySize);
+
+	@Modifying
+	@Query("UPDATE ReservationSlot rs SET rs.availablePartySize = rs.availablePartySize + :partySize " +
+		"WHERE rs.id = :slotId")
+	int increaseAvailablePartySize(@Param("slotId") Long slotId, @Param("partySize") int partySize);
 }

--- a/src/main/java/com/goorm/ticker/restaurant/repository/ReservationSlotRepository.java
+++ b/src/main/java/com/goorm/ticker/restaurant/repository/ReservationSlotRepository.java
@@ -20,12 +20,12 @@ public interface ReservationSlotRepository extends JpaRepository<ReservationSlot
 		@Param("restaurantId") Long restaurantId);
 
 	@Modifying
-	@Query("UPDATE ReservationSlot rs SET rs.availablePartySize = rs.availablePartySize - :partySize " +
-		"WHERE rs.id = :slotId AND rs.availablePartySize >= :partySize")
-	int decreaseAvailablePartySize(@Param("slotId") Long slotId, @Param("partySize") int partySize);
+	@Query("UPDATE ReservationSlot rs SET rs.availablePartySize = rs.availablePartySize - :partySize "
+		+ "WHERE rs.id = :slotId AND rs.availablePartySize >= :partySize")
+	void decreaseAvailablePartySize(@Param("slotId") Long slotId, @Param("partySize") int partySize);
 
 	@Modifying
-	@Query("UPDATE ReservationSlot rs SET rs.availablePartySize = rs.availablePartySize + :partySize " +
-		"WHERE rs.id = :slotId")
-	int increaseAvailablePartySize(@Param("slotId") Long slotId, @Param("partySize") int partySize);
+	@Query("UPDATE ReservationSlot rs SET rs.availablePartySize = rs.availablePartySize + :partySize "
+		+ "WHERE rs.id = :slotId")
+	void increaseAvailablePartySize(@Param("slotId") Long slotId, @Param("partySize") int partySize);
 }

--- a/src/test/java/com/goorm/ticker/fixture/UserFixture.java
+++ b/src/test/java/com/goorm/ticker/fixture/UserFixture.java
@@ -46,4 +46,14 @@ public enum UserFixture {
 			.password(password)
 			.build();
 	}
+
+	public User createUserWithId(Long id) {
+		return User.builder()
+			.id(id)
+			.name(name)
+			.loginId(loginId)
+			.password(password)
+			.build();
+	}
+
 }

--- a/src/test/java/com/goorm/ticker/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/controller/ReservationControllerTest.java
@@ -1,23 +1,30 @@
 package com.goorm.ticker.reservation.controller;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDate;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.goorm.ticker.fixture.ReservationFixture;
+import com.goorm.ticker.common.exception.CustomException;
+import com.goorm.ticker.common.exception.ErrorCode;
 import com.goorm.ticker.fixture.ReservationSlotFixture;
 import com.goorm.ticker.fixture.RestaurantFixture;
 import com.goorm.ticker.fixture.UserFixture;
@@ -25,11 +32,16 @@ import com.goorm.ticker.reservation.Entity.Reservation;
 import com.goorm.ticker.reservation.Entity.ReservationStatus;
 import com.goorm.ticker.reservation.dto.request.ReservationCreateRequest;
 import com.goorm.ticker.reservation.dto.response.ReservationCreateResponse;
+import com.goorm.ticker.reservation.repository.ReservationRepository;
 import com.goorm.ticker.reservation.service.ReservationService;
 import com.goorm.ticker.restaurant.entity.ReservationSlot;
 import com.goorm.ticker.restaurant.entity.Restaurant;
 import com.goorm.ticker.user.entity.User;
+import com.goorm.ticker.user.repository.UserRepository;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @WebMvcTest(ReservationController.class)
 @ExtendWith(MockitoExtension.class)
 public class ReservationControllerTest {
@@ -42,63 +54,82 @@ public class ReservationControllerTest {
 	@MockitoBean
 	private ReservationService reservationService;
 
-	private final RestaurantFixture restaurantFixture = RestaurantFixture.RESTAURANT_FIXTURE_1;
-	private final ReservationSlotFixture slotFixture = ReservationSlotFixture.SLOT_FIXTURE_1;
-	private final UserFixture userFixture = UserFixture.USER_FIXTURE_1;
-	private final ReservationFixture reservationFixture = ReservationFixture.RESERVATION_FIXTURE_1;
+	@MockitoBean
+	private UserRepository userRepository;
 
-	@DisplayName("POST /api/reservations - 예약 생성 성공")
+	@MockitoBean
+	private ReservationRepository reservationRepository;
+
+	private MockHttpSession session;
+	private Restaurant restaurant;
+	private ReservationSlot reservationSlot;
+	private User user;
+	private Reservation reservation;
+
+	@BeforeEach
+	void setUp() {
+		// 세션 초기화
+		session = new MockHttpSession();
+
+		// 사용자 데이터 설정 및 저장
+		user = UserFixture.USER_FIXTURE_1.createUserWithId(1L);
+		when(userRepository.findById(user.getId())).thenReturn(java.util.Optional.of(user));
+		session.setAttribute("userId", user.getId());
+
+		// 식당 및 예약 슬롯 데이터 설정
+		restaurant = RestaurantFixture.RESTAURANT_FIXTURE_1.createRestaurant();
+		reservationSlot = ReservationSlotFixture.SLOT_FIXTURE_1.createSlot(restaurant);
+	}
+
+	@DisplayName("POST /reservations - 예약 생성 성공")
 	@Test
 	void testCreateReservation() throws Exception {
-		// Given
-		Restaurant restaurant = restaurantFixture.createRestaurant();
-		ReservationSlot reservationSlot = slotFixture.createSlot(restaurant);
-		User user = userFixture.createUser();
-		Reservation reservation = reservationFixture.createReservation(restaurant, reservationSlot, user);
 
+		// Given
 		ReservationCreateRequest request = ReservationCreateRequest.of(
-			1L,
-			1L,
+			user.getId(),
+			restaurant.getRestaurantId(),
 			reservationSlot.getSlotTime(),
-			reservation.getReservationDate(),
-			reservation.getPartySize()
+			LocalDate.parse("2025-02-15"),
+			2
 		);
 
 		ReservationCreateResponse response = ReservationCreateResponse.builder()
 			.reservationId(1L)
 			.restaurantName(restaurant.getRestaurantName())
 			.username(user.getName())
-			.partySize(reservation.getPartySize())
-			.reservationDate(reservation.getReservationDate())
+			.partySize(request.getPartySize())
+			.reservationDate(request.getReservationDate())
 			.reservationTime(reservationSlot.getSlotTime())
-			.status(reservation.getStatus())
+			.status(ReservationStatus.CONFIRMED)
 			.build();
 
-		when(reservationService.reserve(any())).thenReturn(response);
+		when(reservationService.reserve(any(ReservationCreateRequest.class), anyLong()))
+			.thenReturn(response);
 
 		// When & Then
-		mockMvc.perform(post("/reservations")
+		MockHttpServletResponse responseEntity = mockMvc.perform(post("/reservations")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.reservationId").value(response.getReservationId()))
-			.andExpect(jsonPath("$.restaurantName").value(response.getRestaurantName()))
-			.andExpect(jsonPath("$.username").value(response.getUsername()))
-			.andExpect(jsonPath("$.partySize").value(response.getPartySize()))
-			.andExpect(jsonPath("$.status").value(response.getStatus().name()));
+				.content(objectMapper.writeValueAsString(request))
+				.session(session))
+			.andReturn().getResponse();
 
-		verify(reservationService, times(1)).reserve(any());
+		// Then
+		assertThat(responseEntity.getStatus()).isEqualTo(HttpStatus.OK.value());
+		verify(reservationService, times(1)).reserve(any(ReservationCreateRequest.class), anyLong());
+
+		assertThat(responseEntity.getContentAsString()).isNotEmpty();
+
+		String responseBody = responseEntity.getContentAsString();
+		ReservationCreateResponse reservationResponse = objectMapper.readValue(responseBody,
+			ReservationCreateResponse.class);
+		assertThat(reservationResponse.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 	}
 
 	@DisplayName("PATCH /reservations/{reservationId} - 예약 상태 업데이트 성공")
 	@Test
 	void testUpdateReservationStatus() throws Exception {
 		// Given
-		Restaurant restaurant = restaurantFixture.createRestaurant();
-		ReservationSlot reservationSlot = slotFixture.createSlot(restaurant);
-		User user = userFixture.createUser();
-		Reservation reservation = reservationFixture.createReservation(restaurant, reservationSlot, user);
-
 		Long reservationId = 1L;
 		String status = "CONFIRMED";
 		Map<String, String> updateRequest = Map.of("status", status);
@@ -108,17 +139,19 @@ public class ReservationControllerTest {
 			.restaurantName(restaurant.getRestaurantName())
 			.username(user.getName())
 			.reservationTime(reservationSlot.getSlotTime())
-			.reservationDate(reservation.getReservationDate())
-			.partySize(reservation.getPartySize())
+			.reservationDate(LocalDate.parse("2025-02-15"))
+			.partySize(2)
 			.status(ReservationStatus.CONFIRMED)
 			.build();
 
-		when(reservationService.updateReservation(eq(reservationId), eq(status))).thenReturn(response);
+		when(reservationService.updateReservation(eq(reservationId), eq(status), eq(user.getId())))
+			.thenReturn(response);
 
 		// When & Then
 		mockMvc.perform(patch("/reservations/{reservationId}", reservationId)
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(updateRequest)))
+				.content(objectMapper.writeValueAsString(updateRequest))
+				.session(session))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.reservationId").value(response.getReservationId()))
 			.andExpect(jsonPath("$.restaurantName").value(response.getRestaurantName()))
@@ -126,6 +159,53 @@ public class ReservationControllerTest {
 			.andExpect(jsonPath("$.partySize").value(response.getPartySize()))
 			.andExpect(jsonPath("$.status").value(response.getStatus().name()));
 
-		verify(reservationService, times(1)).updateReservation(eq(reservationId), eq(status));
+		verify(reservationService, times(1))
+			.updateReservation(eq(reservationId), eq(status), eq(user.getId()));
+	}
+
+	@DisplayName("PATCH /reservations/{reservationId} - 예약 상태 업데이트 실패 (권한 없음 403)")
+	@Test
+	void testUpdateReservationStatus_Fail_Unauthorized() throws Exception {
+		// Given
+		Long reservationId = 1L;
+		String status = "CANCELLED";
+		Map<String, String> updateRequest = Map.of("status", status);
+
+		// 세션 내 유저 ID와 예약의 유저 ID가 다름
+		Long otherUserId = 999L;
+		session.setAttribute("userId", otherUserId);
+
+		when(reservationService.updateReservation(eq(reservationId), eq(status), eq(otherUserId)))
+			.thenThrow(new CustomException(ErrorCode.FORBIDDEN_RESERVATION_ACCESS));
+
+		// When & Then
+		mockMvc.perform(patch("/reservations/{reservationId}", reservationId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateRequest))
+				.session(session))
+			.andExpect(status().isForbidden()); // 권한 없음
+
+		verify(reservationService, times(1))
+			.updateReservation(eq(reservationId), eq(status), eq(otherUserId));
+	}
+
+	@DisplayName("POST /reservations - 세션 없음 (401 Unauthorized)")
+	@Test
+	void testCreateReservation_Fail_NoSession() throws Exception {
+		// Given
+		session.setAttribute("userId", null);
+		ReservationCreateRequest request = ReservationCreateRequest.of(
+			user.getId(),
+			restaurant.getRestaurantId(),
+			reservationSlot.getSlotTime(),
+			LocalDate.parse("2025-02-15"),
+			2
+		);
+
+		// When & Then
+		mockMvc.perform(post("/reservations")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
 	}
 }

--- a/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.goorm.ticker.notification.repository.NotificationRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import com.goorm.ticker.common.exception.CustomException;
 import com.goorm.ticker.fixture.ReservationSlotFixture;
 import com.goorm.ticker.fixture.RestaurantFixture;
+import com.goorm.ticker.notification.repository.NotificationRepository;
 import com.goorm.ticker.reservation.dto.request.ReservationCreateRequest;
 import com.goorm.ticker.reservation.repository.ReservationRepository;
 import com.goorm.ticker.reservation.service.ReservationService;
@@ -133,7 +133,7 @@ public class ReservationConcurrencyTest {
 						reservationTime,
 						reservationDate,
 						partySize);
-					reservationService.reserve(request);
+					reservationService.reserve(request, index);
 					successCount.incrementAndGet();
 					log.info("[O] 성공 - 유저 ID: {} | 예약 일시 : {} {}", (index), reservationDate,
 						reservationTime);

--- a/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/integration/ReservationConcurrencyTest.java
@@ -6,9 +6,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
@@ -21,10 +26,13 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.goorm.ticker.common.exception.CustomException;
+import com.goorm.ticker.common.exception.ErrorCode;
 import com.goorm.ticker.fixture.ReservationSlotFixture;
 import com.goorm.ticker.fixture.RestaurantFixture;
 import com.goorm.ticker.notification.repository.NotificationRepository;
+import com.goorm.ticker.reservation.Entity.ReservationStatus;
 import com.goorm.ticker.reservation.dto.request.ReservationCreateRequest;
+import com.goorm.ticker.reservation.dto.response.ReservationCreateResponse;
 import com.goorm.ticker.reservation.repository.ReservationRepository;
 import com.goorm.ticker.reservation.service.ReservationService;
 import com.goorm.ticker.restaurant.entity.ReservationSlot;
@@ -135,8 +143,6 @@ public class ReservationConcurrencyTest {
 						partySize);
 					reservationService.reserve(request, index);
 					successCount.incrementAndGet();
-					log.info("[O] 성공 - 유저 ID: {} | 예약 일시 : {} {}", (index), reservationDate,
-						reservationTime);
 				} catch (CustomException e) {
 					failureCount.incrementAndGet();
 					log.warn("[X] 실패 - 유저 ID: {} | 에러 코드: {} | {} ", (index), e.getErrorCode(),
@@ -149,18 +155,150 @@ public class ReservationConcurrencyTest {
 
 		latch.await();
 		executorService.shutdown();
-		log.info("--------------------------------------------");
 		long endTime = System.currentTimeMillis();
 
-		log.info("실행 시간: {} ms", (endTime - startTime));
-		log.info("예약 성공: {}", successCount.get());
-		log.warn("예약 실패: {}", failureCount.get());
+		long totalReservations = reservationRepository.countByStatus(ReservationStatus.CONFIRMED);
 
-		// DB에서 실제 예약된 건수 확인
-		long totalReservations = reservationRepository.count();
-		log.info("실제 DB 예약 건수: {}", totalReservations);
+		logReservationResults(successCount, failureCount, totalReservations, "예약");
+		log.info("실행 시간: {} ms", (endTime - startTime));
 
 		assertThat(successCount.get()).isEqualTo(testSlots.get(0).getAvailablePartySize() / partySize);
 		assertThat(totalReservations).isEqualTo(testSlots.get(0).getAvailablePartySize() / partySize);
+	}
+
+	@Test
+	@DisplayName("예약과 취소가 동시에 실행되면서 정합성이 유지되는지 테스트")
+	void testConcurrentReservationAndCancellation() throws InterruptedException, ExecutionException {
+		int threadCount = 100; // 동시 실행할 요청 개수
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount); // 모든 작업이 끝날 때까지 대기
+
+		Long restaurantId = restaurantInstant.getRestaurantId();
+		LocalTime reservationTime = LocalTime.of(12, 0);
+		LocalDate reservationDate = LocalDate.now();
+		int partySize = 2;
+
+		AtomicInteger successReservationCount = new AtomicInteger(0);
+		AtomicInteger failureReservationCount = new AtomicInteger(0);
+		AtomicInteger successCancelCount = new AtomicInteger(0);
+		AtomicInteger failureCancelCount = new AtomicInteger(0);
+
+		ConcurrentHashMap<Long, Long> successfulReservations = new ConcurrentHashMap<>();
+		List<Long> reservationUserIds = new CopyOnWriteArrayList<>();
+		List<Future<?>> reservationFutures = new ArrayList<>();
+
+		// 미리 5명 예약 진행
+		log.info("테스트 세팅 - 5명의 사용자가 미리 예약을 진행합니다.");
+		for (long i = startUserId; i < startUserId + 5; i++) {
+			final long userId = i;
+			reservationFutures.add(executorService.submit(() -> {
+				try {
+					ReservationCreateRequest request = ReservationCreateRequest.of(
+						userId, restaurantId, reservationTime, reservationDate, partySize);
+					ReservationCreateResponse response = reservationService.reserve(request, userId);
+					successfulReservations.put(userId, response.getReservationId());
+					reservationUserIds.add(userId);
+					successReservationCount.incrementAndGet();
+				} catch (CustomException e) {
+					failureReservationCount.incrementAndGet();
+					log.warn("[X] 예약 실패 - 유저 ID: {} | {} {} ", userId, e.getErrorCode(),
+						e.getErrorCode().getMessage());
+				} finally {
+					latch.countDown();
+				}
+			}));
+		}
+
+		// 모든 예약이 완료될 때까지 대기
+		for (Future<?> future : reservationFutures) {
+			future.get();
+		}
+
+		Thread.sleep(1000);
+
+		log.info("테스트 시작 - 100명의 유저가 동시에 예약과 취소 요청을 보냅니다.");
+
+		long startTime = System.currentTimeMillis();
+		for (long i = startUserId; i < startUserId + threadCount; i++) {
+			final long userId = i;
+			executorService.execute(() -> {
+				try {
+					boolean isReservation = ThreadLocalRandom.current().nextBoolean(); // 랜덤하게 예약/취소 결정
+
+					if (isReservation) {
+						// 🟢 예약 요청
+						ReservationCreateRequest request = ReservationCreateRequest.of(
+							userId,
+							restaurantId,
+							reservationTime,
+							reservationDate,
+							partySize
+						);
+						ReservationCreateResponse response = reservationService.reserve(request, userId);
+						successfulReservations.put(userId, response.getReservationId()); // 성공한 예약 저장
+						successReservationCount.incrementAndGet();
+						reservationUserIds.add(userId);
+					} else {
+						// 취소 요청 (랜덤한 유저 선택)
+						if (successfulReservations.isEmpty() || reservationUserIds.isEmpty()) {
+							log.warn("[X] 취소 실패 - 예약 없음");
+							failureCancelCount.incrementAndGet();
+							return;
+						}
+						Long randomUserId = reservationUserIds.get(
+							ThreadLocalRandom.current().nextInt(reservationUserIds.size()));
+						reservationUserIds.remove(randomUserId);
+						Long reservationId = successfulReservations.remove(randomUserId);
+						if (reservationId == null) {
+							log.warn("[X] 취소 실패 - 예약 없음 (랜덤 유저 ID: {})", randomUserId);
+							failureCancelCount.incrementAndGet();
+							return;
+						}
+						reservationService.updateReservation(reservationId, "CANCELLED", randomUserId);
+						successCancelCount.incrementAndGet();
+
+					}
+				} catch (CustomException e) {
+					if (e.getErrorCode() == ErrorCode.PARTY_SIZE_EXCEEDED) {
+						failureReservationCount.incrementAndGet();
+					} else {
+						failureCancelCount.incrementAndGet();
+					}
+					log.warn("[X] 예약 실패 - 유저 ID: {} | {} {}", userId,
+						e.getErrorCode(), e.getErrorCode().getMessage());
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executorService.shutdown();
+		long endTime = System.currentTimeMillis();
+		log.info("실행 시간: {} ms", (endTime - startTime));
+
+		long totalReservations = reservationRepository.countByStatus(ReservationStatus.CONFIRMED);
+		long totalCancelReservations = reservationRepository.countByStatus(ReservationStatus.CANCELLED);
+
+		logReservationResults(successCancelCount, failureCancelCount, totalCancelReservations, "취소");
+		logReservationResults(successReservationCount, failureReservationCount, totalReservations, "예약");
+
+		// 검증
+		assertThat(successReservationCount.get()).isGreaterThan(0);
+		assertThat(successCancelCount.get()).isGreaterThan(0);
+		assertThat(totalReservations).isLessThanOrEqualTo(testSlots.get(0).getAvailablePartySize() / partySize);
+	}
+
+	private void logReservationResults(
+		AtomicInteger succssCount,
+		AtomicInteger failureCount,
+		long totalCount,
+		String type
+	) {
+		log.info("---------------------------------------------");
+		log.info("{} 성공: {}", type, succssCount.get());
+		log.warn("{} 실패: {}", type, failureCount.get());
+
+		log.info("최종 DB {} 건수: {}", type, totalCount);
 	}
 }

--- a/src/test/java/com/goorm/ticker/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/service/ReservationServiceTest.java
@@ -66,13 +66,14 @@ class ReservationServiceTest {
 		restaurantManual = RestaurantFixture.RESTAURANT_FIXTURE_2.createRestaurant();
 		reservationSlotInstant = ReservationSlotFixture.SLOT_FIXTURE_1.createSlot(restaurantInstant);
 		reservationSlotManual = ReservationSlotFixture.SLOT_FIXTURE_1.createSlot(restaurantManual);
-		user = UserFixture.USER_FIXTURE_1.createUser();
+		user = UserFixture.USER_FIXTURE_1.createUserWithId(1L);
 		reservationInstant = ReservationFixture.RESERVATION_FIXTURE_1.createReservation(restaurantInstant,
 			reservationSlotInstant,
 			user);
 		reservationManual = ReservationFixture.RESERVATION_FIXTURE_1.createReservation(restaurantManual,
 			reservationSlotManual,
 			user);
+
 	}
 
 	@DisplayName("단일 예약을 성공합니다. -> 즉시 예약 확정 정책")
@@ -91,7 +92,7 @@ class ReservationServiceTest {
 		when(reservationRepository.save(any(Reservation.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
 		// When
-		ReservationCreateResponse response = reservationService.reserve(request);
+		ReservationCreateResponse response = reservationService.reserve(request, user.getId());
 
 		// Then
 		assertSoftly(softly -> {
@@ -121,7 +122,7 @@ class ReservationServiceTest {
 		when(reservationRepository.save(any(Reservation.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
 		// When
-		ReservationCreateResponse response = reservationService.reserve(request);
+		ReservationCreateResponse response = reservationService.reserve(request, user.getId());
 
 		// Then
 		assertSoftly(softly -> {
@@ -151,7 +152,7 @@ class ReservationServiceTest {
 			.thenReturn(Optional.empty());
 
 		// When & Then
-		Assertions.assertThatThrownBy(() -> reservationService.reserve(request))
+		Assertions.assertThatThrownBy(() -> reservationService.reserve(request, user.getId()))
 			.isInstanceOf(CustomException.class)
 			.satisfies(ex -> {
 				CustomException customException = (CustomException)ex;
@@ -184,7 +185,7 @@ class ReservationServiceTest {
 			.thenReturn(Optional.empty());
 
 		// When & Then
-		Assertions.assertThatThrownBy(() -> reservationService.reserve(request))
+		Assertions.assertThatThrownBy(() -> reservationService.reserve(request, user.getId()))
 			.isInstanceOf(CustomException.class)
 			.satisfies(ex -> {
 				CustomException customException = (CustomException)ex;
@@ -221,7 +222,7 @@ class ReservationServiceTest {
 			.thenReturn(Optional.of(user));
 
 		// When & Then
-		Assertions.assertThatThrownBy(() -> reservationService.reserve(request))
+		Assertions.assertThatThrownBy(() -> reservationService.reserve(request, user.getId()))
 			.isInstanceOf(CustomException.class)
 			.satisfies(ex -> {
 				CustomException customException = (CustomException)ex;
@@ -246,10 +247,10 @@ class ReservationServiceTest {
 			.thenReturn(Optional.of(reservationInstant));
 
 		int initialAvailablePartySize = reservationSlotInstant.getAvailablePartySize();
-
+		when(userRepository.save(any())).thenReturn(user);
 		// When
 		ReservationCreateResponse response = reservationService.updateReservation(
-			reservationInstant.getReservationId(), "CONFIRMED");
+			reservationInstant.getReservationId(), "CONFIRMED", user.getId());
 
 		// Then
 		Assertions.assertThat(response).isNotNull();
@@ -263,26 +264,45 @@ class ReservationServiceTest {
 
 	@DisplayName("예약 대기 상태에서 취소 상태로 변경합니다.")
 	@Test
-	void testUpdateReservationStatusToCancelled() {
-		// Given
-		Long reservationId = reservationManual.getReservationId();
+	void testReserveAndThenCancel() {
+		// Given - 예약 생성
+		ReservationCreateRequest request = ReservationCreateRequest.of(
+			1L, restaurantManual.getRestaurantId(), reservationSlotManual.getSlotTime(),
+			reservationManual.getReservationDate(),
+			reservationManual.getPartySize());
 
-		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservationManual));
+		when(restaurantRepository.findById(request.getRestaurantId())).thenReturn(Optional.of(restaurantManual));
+		when(reservationSlotRepository.findBySlotTimeAndRestaurantIdWithLock(
+			request.getReservationTime(), request.getRestaurantId())).thenReturn(Optional.of(reservationSlotManual));
+		when(userRepository.findById(request.getUserId())).thenReturn(Optional.of(user));
+		when(reservationRepository.save(any(Reservation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		ReservationCreateResponse reservationResponse = reservationService.reserve(request, user.getId());
+
+		// Then - 예약이 정상적으로 생성되었는지 확인
+		assertThat(reservationResponse).isNotNull();
+		assertThat(reservationResponse.getStatus()).isEqualTo(ReservationStatus.PENDING);
+
+		// Given - 예약이 생성된 상태에서 취소 진행
+		Long reservationId = reservationResponse.getReservationId();
+		Long userId = user.getId();
+
+		when(reservationRepository.findById(reservationId)).thenReturn(
+			Optional.of(Reservation.of(restaurantManual, reservationSlotManual, request.getReservationDate(),
+				user, request.getPartySize(), ReservationStatus.PENDING)));
 
 		int initialAvailablePartySize = reservationSlotManual.getAvailablePartySize();
-		// When
-		ReservationCreateResponse response = reservationService.updateReservation(reservationId, "CANCELLED");
 
-		// Then
-		Assertions.assertThat(response).isNotNull();
-		Assertions.assertThat(response.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+		// When - 예약 취소
+		ReservationCreateResponse cancelResponse = reservationService.updateReservation(reservationId, "CANCELLED",
+			userId);
 
-		Assertions.assertThat(reservationManual.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-		Assertions.assertThat(reservationSlotManual.getAvailablePartySize()).isEqualTo(
-			initialAvailablePartySize
-		);
-
-		verify(reservationRepository, times(1)).findById(reservationId);
+		// Then - 예약 취소 검증
+		assertSoftly(softly -> {
+			softly.assertThat(cancelResponse).isNotNull();
+			softly.assertThat(cancelResponse.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			softly.assertThat(reservationSlotManual.getAvailablePartySize()).isEqualTo(initialAvailablePartySize);
+		});
 	}
 
 	@DisplayName("예약 확정에서 취소로 변경하여 예약 가능 인원이 증가합니다.")
@@ -297,7 +317,7 @@ class ReservationServiceTest {
 
 		// When
 		ReservationCreateResponse response = reservationService.updateReservation(reservation2.getReservationId(),
-			"CANCELLED");
+			"CANCELLED", user.getId());
 
 		// Then
 		Assertions.assertThat(response).isNotNull();
@@ -319,7 +339,8 @@ class ReservationServiceTest {
 
 		// When
 		Assertions.assertThatThrownBy(
-				() -> reservationService.updateReservation(reservation3.getReservationId(), "CANCELLED"))
+				() -> reservationService.updateReservation(reservation3.getReservationId(), "CANCELLED",
+					user.getId()))
 			.isInstanceOf(CustomException.class)
 			.satisfies(ex -> {
 				CustomException customException = (CustomException)ex;
@@ -345,7 +366,8 @@ class ReservationServiceTest {
 
 		// When
 		Assertions.assertThatThrownBy(
-				() -> reservationService.updateReservation(reservation4.getReservationId(), "CANCELLED"))
+				() -> reservationService.updateReservation(reservation4.getReservationId(), "CANCELLED",
+					user.getId()))
 			.isInstanceOf(CustomException.class)
 			.satisfies(ex -> {
 				CustomException customException = (CustomException)ex;
@@ -369,17 +391,37 @@ class ReservationServiceTest {
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservationInstant));
 
 		// When & Then
-		Assertions.assertThatThrownBy(() -> reservationService.updateReservation(reservationId, invalidStatus))
+		Assertions.assertThatThrownBy(() -> reservationService.updateReservation(reservationId, invalidStatus,
+				user.getId()))
 			.isInstanceOf(CustomException.class)
 			.satisfies(ex -> {
 				CustomException customException = (CustomException)ex;
 				assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.INVALID_RESERVATION_STATUS);
 				assertThat(customException.getErrorCode().getMessage()).isEqualTo("존재하지 않는 예약 상태입니다.");
-				assertThat(customException.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(customException.getErrorCode().getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
 			});
 
 		// Verify
 		verify(reservationRepository, times(1)).findById(reservationId);
 		verifyNoMoreInteractions(reservationRepository);
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 예약 상태 변경 시 예외 발생")
+	void testUpdateReservation_UnauthorizedUser() {
+		Long reservationId = reservationInstant.getReservationId();
+		Long unauthorizedUserId = 999L; // 예약한 사용자가 아닌 다른 ID
+
+		// When & Then
+		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservationInstant));
+		Assertions.assertThatThrownBy(() -> reservationService.updateReservation(reservationId, "CONFIRMED",
+				unauthorizedUserId))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> {
+				CustomException customException = (CustomException)ex;
+				assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN_RESERVATION_ACCESS);
+				assertThat(customException.getErrorCode().getMessage()).isEqualTo("해당 예약에 접근할 수 없습니다.");
+				assertThat(customException.getErrorCode().getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+			});
 	}
 }

--- a/src/test/java/com/goorm/ticker/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/goorm/ticker/reservation/service/ReservationServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goorm.ticker.common.exception.CustomException;
@@ -34,6 +35,9 @@ import com.goorm.ticker.restaurant.repository.RestaurantRepository;
 import com.goorm.ticker.user.entity.User;
 import com.goorm.ticker.user.repository.UserRepository;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 class ReservationServiceTest {
 
 	@InjectMocks
@@ -309,23 +313,72 @@ class ReservationServiceTest {
 	@Test
 	void testUpdateReservationStatusFromConfirmedToCancelled() {
 		// Given
-		ReservationSlot reservationSlot2 = ReservationSlotFixture.SLOT_FIXTURE_2.createSlot(restaurantInstant);
-		Reservation reservation2 = ReservationFixture.RESERVATION_FIXTURE_2.createReservation(restaurantInstant,
-			reservationSlot2, user);
-		when(reservationRepository.findById(reservation2.getReservationId())).thenReturn(Optional.of(reservation2));
-		int initialAvailablePartySize = reservationSlot2.getAvailablePartySize();
+		ReservationCreateRequest request = ReservationCreateRequest.of(
+			1L, restaurantInstant.getRestaurantId(), reservationSlotInstant.getSlotTime(),
+			reservationInstant.getReservationDate(),
+			reservationInstant.getPartySize());
+		log.info("reservationInstant.getPartySize(): {}", reservationInstant.getPartySize());
 
-		// When
-		ReservationCreateResponse response = reservationService.updateReservation(reservation2.getReservationId(),
-			"CANCELLED", user.getId());
+		when(restaurantRepository.findById(request.getRestaurantId())).thenReturn(Optional.of(restaurantInstant));
+		when(reservationSlotRepository.findBySlotTimeAndRestaurantIdWithLock(
+			request.getReservationTime(), request.getRestaurantId())).thenReturn(Optional.of(reservationSlotInstant));
+		when(userRepository.findById(request.getUserId())).thenReturn(Optional.of(user));
+
+		when(reservationRepository.save(any(Reservation.class))).thenAnswer(invocation -> {
+			Reservation reservation = invocation.getArgument(0);
+			ReflectionTestUtils.setField(reservation, "reservationId", 1L);
+
+			if (reservation.getStatus() == ReservationStatus.CONFIRMED) {
+				reservationSlotInstant.updateAvailablePartySize(
+					reservationSlotInstant.getAvailablePartySize() - reservation.getPartySize());
+			}
+			return reservation;
+		});
+
+		int initialAvailablePartySize = reservationSlotInstant.getAvailablePartySize();
+		log.info("initialAvailablePartySize : {}", initialAvailablePartySize);
+		ReservationCreateResponse reservationResponse = reservationService.reserve(request, user.getId());
+
+		// Then - 예약이 정상적으로 생성되었는지 확인
+		assertThat(reservationResponse).isNotNull();
+		assertThat(reservationResponse.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+		// Given - 예약이 생성된 상태에서 취소 진행
+		Long reservationId = reservationResponse.getReservationId();
+		Long userId = user.getId();
+		when(reservationRepository.findById(reservationId)).thenAnswer(invocation -> {
+			Reservation updatedReservation = Reservation.of(
+				restaurantInstant,
+				reservationSlotInstant,
+				request.getReservationDate(),
+				user,
+				request.getPartySize(),
+				ReservationStatus.CONFIRMED);
+			if (updatedReservation.getStatus() == ReservationStatus.CONFIRMED) {
+				reservationSlotInstant.updateAvailablePartySize(
+					reservationSlotInstant.getAvailablePartySize() + updatedReservation.getPartySize());
+			}
+			ReflectionTestUtils.setField(updatedReservation, "reservationId", reservationId);
+			return Optional.of(updatedReservation);
+		});
+
+		when(reservationSlotRepository.findBySlotTimeAndRestaurantIdWithLock(
+			request.getReservationTime(), request.getRestaurantId())).thenReturn(Optional.of(reservationSlotInstant));
+
+		ReservationCreateResponse response = reservationService.updateReservation(reservationId,
+			"CANCELLED", userId);
+
+		ReservationSlot updatedSlot = reservationSlotRepository.findBySlotTimeAndRestaurantIdWithLock(
+			request.getReservationTime(), request.getRestaurantId()).orElseThrow();
 
 		// Then
 		Assertions.assertThat(response).isNotNull();
 		Assertions.assertThat(response.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-		Assertions.assertThat(reservationSlot2.getAvailablePartySize())
-			.isEqualTo(initialAvailablePartySize + reservation2.getPartySize());
 
-		verify(reservationRepository, times(1)).findById(reservation2.getReservationId());
+		// 예약 취소 후 가용 인원 증가 확인
+		assertThat(updatedSlot.getAvailablePartySize())
+			.isEqualTo(initialAvailablePartySize); // 원래 상태로 복구됨
+
 	}
 
 	@DisplayName("예약 취소에서 취소로 변경 시 예외를 발생시킵니다.")


### PR DESCRIPTION
## **PR 타입 (하나 이상의 PR 타입을 선택해주세요)**

- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## **반영 브랜치**
- `feature/#3 -> dev`


## **이슈**
>-  #14 
- 예약 취소 & 변경 처리 확인 및 개선 (락을 걸고 잔여 인원 복구)
- HttpSession으로 사용자 확인 로직 추가


## **작업 사항**
- 예약 처리 로직 개선
   - ReservationService.reserve()
   - 비관적 락(PESSIMISTIC_WRITE) 적용하여 ReservationSlot 조회 시 동시성 문제 방지
   - **잔여 인원 감소 쿼리 분리 (decreaseAvailablePartySize())** 하여 예약 성공 후 원자적으로 처리
   - 예약 성공 시 남은 예약 가능 인원을 로그 출력하여 확인 가능하도록 함.
- 예약 취소 처리 로직 개선
   - ReservationService.updateReservation()
   - 예약 취소 시 increaseAvailablePartySize() 쿼리 적용하여 잔여 인원 원복 처리 보장
   - 기존 Reservation.cancelReservation() 로직 호출 후 잔여 인원 증가하는지 검증 추가
- 동시성 테스트 코드 리팩토링
   - 취소/생성 동시에 이뤄질 때 상황 가정한 테스트 추가
   - logReservationResults() 메서드로 중복된 로깅 코드 정리
- HttpSession을 통해 현재 로그인된 사용자의 정보를 확인하고 예약 요청 시 유효성 검사 추가
  - 인증, 인가 구분하여 ErrorCode 수정


## **리뷰어에게 전달 사항**
- 테스트 코드 관련 조언 부탁드립니다!
- 추후 발생할 수 있는 사이드이펙트에 대해서 생각나신다면 공유 부탁드립니다!
